### PR TITLE
Disable the QM error handler in Cloud

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -4,6 +4,7 @@ namespace Altis\Dev_Tools;
 
 use const Altis\ROOT_DIR;
 use function Altis\get_config;
+use function Altis\get_environment_architecture;
 
 /**
  * Bootstrap.
@@ -19,6 +20,12 @@ function on_plugins_loaded() {
 	$config = get_config()['modules']['dev-tools'];
 
 	if ( $config['query-monitor'] ) {
+		// In Cloud environments, disable the Query Monitor error handler
+		// as this will override our own error handler in Cloud.
+		if ( in_array( get_environment_architecture(), [ 'ec2', 'ecs' ], true ) ) {
+			define( 'QM_DISABLE_ERROR_HANDLER', true );
+		}
+
 		// Hide the db.php dropin installation warning and prompt.
 		add_filter( 'qm/show_extended_query_prompt', '__return_false' );
 		require_once ROOT_DIR . '/vendor/johnbillion/query-monitor/query-monitor.php';


### PR DESCRIPTION
there can only be one `error_handler` and we don't want QM to swallow all the erorrs in Cloud, as we also have an error handler.