### PR TITLE
Add QM protocol handlers for clickable stack traces

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -35,3 +35,19 @@ You can also add the `view_query_monitor` capability to users to permanently gra
 ### Activating in other environments
 
 You can enable this on other environments by setting the `altis.modules.dev-tools.enabled` configuration option to true. We recommend using [environment-specific configuration](docs://getting-started/configuration.md#environment-specific-configuration) to only enable it on environments where necessary, as it has a small performance cost.
+
+### Editor Stack Traces
+
+When viewing a stack trace of a PHP warning or error, the developer tools can turn these into clickable links that open in your editor. To enable this, define `QM_LOCAL_EDITOR` like this:
+
+```php
+define( 'QM_LOCAL_EDITOR', 'phpstorm' );
+```
+
+Valid values include:
+
+ - `phpstorm`
+ - `vscode`
+ - `atom`
+ - `sublime`
+ - `netbeans`

--- a/docs/README.md
+++ b/docs/README.md
@@ -36,6 +36,7 @@ You can also add the `view_query_monitor` capability to users to permanently gra
 
 You can enable this on other environments by setting the `altis.modules.dev-tools.enabled` configuration option to true. We recommend using [environment-specific configuration](docs://getting-started/configuration.md#environment-specific-configuration) to only enable it on environments where necessary, as it has a small performance cost.
 
+
 ### Editor Stack Traces
 
 When viewing a stack trace of a PHP warning or error, the developer tools can turn these into clickable links that open in your editor. To enable this, define `QM_LOCAL_EDITOR` like this:

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -37,7 +37,7 @@ function on_plugins_loaded() {
 }
 
 function qm_file_path_map( $map ) : array {
-	// Handle Chassis
+	// Chassis and Local Server
 	if ( file_exists( '/etc/chassis-constants' ) ) {
 		$json_string = file_get_contents( '/etc/chassis-constants' );
 		$data = json_decode( $json_string, true );
@@ -51,5 +51,26 @@ function qm_file_path_map( $map ) : array {
 }
 
 function qm_file_link_format( $format ) : string {
-	return 'subl://open/?url=file://%f&line=%l';
+	$editor = 'phpstorm';
+	if ( defined( 'QM_LOCAL_EDITOR' ) ) {
+		$editor = QM_LOCAL_EDITOR;
+	}
+	return qm_file_link_editor_format( $format, $editor );
+}
+
+function qm_file_link_editor_format( $format, $editor=null ) : string {
+	switch ( $editor ) {
+		case 'phpstorm':
+			return 'phpstorm://open?file=%f&line=%l';
+		case 'vscode':
+			return 'vscode://file/%f:%l';
+		case 'atom':
+			return 'atom://open/?url=file://%f&line=%l';
+		case 'sublime':
+			return 'subl://open/?url=file://%f&line=%l';
+		case 'netbeans':
+			return 'nbopen://%f:%l';
+		default:
+			return $format;
+	}
 }

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -11,7 +11,11 @@ use function Altis\get_environment_architecture;
  */
 function bootstrap() {
 	add_action( 'plugins_loaded', __NAMESPACE__ . '\\on_plugins_loaded', 1 );
+	add_filter( 'qm/output/file_path_map', __NAMESPACE__ . '\\qm_file_path_map', 1 );
+	add_filter( 'qm/output/file_link_format',  __NAMESPACE__ . '\\qm_file_link_format', 1 );
 }
+
+$banana = $cucumber['moosh'];
 
 /**
  * Load in other code as necessary.
@@ -30,4 +34,22 @@ function on_plugins_loaded() {
 		add_filter( 'qm/show_extended_query_prompt', '__return_false' );
 		require_once ROOT_DIR . '/vendor/johnbillion/query-monitor/query-monitor.php';
 	}
+}
+
+function qm_file_path_map( $map ) : array {
+	// Handle Chassis
+	if ( file_exists( '/etc/chassis-constants' ) ) {
+		$json_string = file_get_contents( '/etc/chassis-constants' );
+		$data = json_decode( $json_string, true );
+		if ( !empty( $data['synced_folders']['/chassis'] ) ) {
+			$folder_path = $data['synced_folders']['/chassis'].'/content/themes/base';
+			$map['/chassis/'] = $data['synced_folders']['/chassis'] . '/';
+		}
+	}
+
+	return $map;
+}
+
+function qm_file_link_format( $format ) : string {
+	return 'subl://open/?url=file://%f&line=%l';
 }

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -40,7 +40,7 @@ function qm_file_path_map( $map ) : array {
 		$json_string = file_get_contents( '/etc/chassis-constants' );
 		$data = json_decode( $json_string, true );
 		if ( ! empty( $data['synced_folders']['/chassis'] ) ) {
-			$folder_path = $data['synced_folders']['/chassis'].'/content/themes/base';
+			$folder_path = $data['synced_folders']['/chassis'] . '/content/themes/base';
 			$map['/chassis/'] = $data['synced_folders']['/chassis'] . '/';
 		}
 	}

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -11,7 +11,7 @@ use function Altis\get_environment_architecture;
  */
 function bootstrap() {
 	add_action( 'plugins_loaded', __NAMESPACE__ . '\\on_plugins_loaded', 1 );
-	add_filter( 'qm/output/file_link_format', __NAMESPACE__ . '\\qm_file_link_format', 1 );
+	add_filter( 'qm/output/file_link_format', __NAMESPACE__ . '\\set_edit_link_format', 1 );
 }
 
 /**
@@ -40,12 +40,12 @@ function on_plugins_loaded() {
  * @param string $format a protocol URL format
  * @return string a protocol URL format
  */
-function qm_file_link_format( $format ) : string {
+function set_edit_link_format( $format ) : string {
 	$editor = null;
 	if ( defined( 'QM_LOCAL_EDITOR' ) ) {
 		$editor = QM_LOCAL_EDITOR;
 	}
-	return qm_file_link_editor_format( $format, $editor );
+	return get_edit_link_format( $format, $editor );
 }
 
 /**
@@ -56,7 +56,7 @@ function qm_file_link_format( $format ) : string {
  * @param string|null $editor the chosen code editor
  * @return string a protocol URL format
  */
-function qm_file_link_editor_format( $default_format, $editor = null ) : string {
+function get_edit_link_format( $default_format, $editor = null ) : string {
 	switch ( $editor ) {
 		case 'phpstorm':
 			return 'phpstorm://open?file=%f&line=%l';

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -12,10 +12,8 @@ use function Altis\get_environment_architecture;
 function bootstrap() {
 	add_action( 'plugins_loaded', __NAMESPACE__ . '\\on_plugins_loaded', 1 );
 	add_filter( 'qm/output/file_path_map', __NAMESPACE__ . '\\qm_file_path_map', 1 );
-	add_filter( 'qm/output/file_link_format',  __NAMESPACE__ . '\\qm_file_link_format', 1 );
+	add_filter( 'qm/output/file_link_format', __NAMESPACE__ . '\\qm_file_link_format', 1 );
 }
-
-$banana = $cucumber['moosh'];
 
 /**
  * Load in other code as necessary.
@@ -41,7 +39,7 @@ function qm_file_path_map( $map ) : array {
 	if ( file_exists( '/etc/chassis-constants' ) ) {
 		$json_string = file_get_contents( '/etc/chassis-constants' );
 		$data = json_decode( $json_string, true );
-		if ( !empty( $data['synced_folders']['/chassis'] ) ) {
+		if ( ! empty( $data['synced_folders']['/chassis'] ) ) {
 			$folder_path = $data['synced_folders']['/chassis'].'/content/themes/base';
 			$map['/chassis/'] = $data['synced_folders']['/chassis'] . '/';
 		}
@@ -58,7 +56,7 @@ function qm_file_link_format( $format ) : string {
 	return qm_file_link_editor_format( $format, $editor );
 }
 
-function qm_file_link_editor_format( $format, $editor=null ) : string {
+function qm_file_link_editor_format( $format, $editor = null ) : string {
 	switch ( $editor ) {
 		case 'phpstorm':
 			return 'phpstorm://open?file=%f&line=%l';


### PR DESCRIPTION
This implements an MVP for #16, ideally the choice of editor would be provided via the config panel in the browser rather than in PHP