### PR TITLE
Fix PHPUnit Elasticsearch set up

### DIFF
--- a/inc/phpunit/bootstrap.php
+++ b/inc/phpunit/bootstrap.php
@@ -46,6 +46,8 @@ tests_add_filter( 'upload_dir', function( $dir ) {
  */
 define( 'EP_INDEX_PREFIX', 'tests_' );
 tests_add_filter( 'plugins_loaded', function () {
+	global $table_prefix;
+
 	if ( ! function_exists( 'ep_index_exists' ) ) {
 		return;
 	}
@@ -58,10 +60,15 @@ tests_add_filter( 'plugins_loaded', function () {
 		return;
 	}
 
-	exec( 'EP_INDEX_PREFIX=tests_ wp elasticpress index --setup --network-wide --quiet --url=' . WP_TESTS_DOMAIN );
+	exec( sprintf(
+		'TABLE_PREFIX=%s EP_INDEX_PREFIX=%s wp elasticpress index --setup --network-wide --url=%s',
+		$table_prefix,
+		EP_INDEX_PREFIX,
+		WP_TESTS_DOMAIN
+	) );
 
 	error_reporting( $error_reporting_level );
-} );
+}, 11 );
 
 /**
  * Ensure Stream is installed.
@@ -76,7 +83,7 @@ tests_add_filter( 'plugins_loaded', function () {
 /**
  * Modify the cache keys to prevent conflicts.
  */
-define( 'WP_CACHE_KEY_SALT', WP_TESTS_DOMAIN );
+define( 'WP_CACHE_KEY_SALT', 'phpunit' );
 
 // Load custom bootstrap code.
 if ( file_exists( Altis\PHPUNIT_PROJECT_ROOT . '/.config/tests-bootstrap.php' ) ) {

--- a/load.php
+++ b/load.php
@@ -5,6 +5,12 @@ namespace Altis\Dev_Tools; // @codingStandardsIgnoreLine
 use function Altis\get_environment_type;
 use function Altis\register_module;
 
+// In order to configure tests properly we need to be able to ensure
+// WP CLI commands can be run pointing to the correct tables.
+if ( getenv( 'TABLE_PREFIX' ) ) {
+	$table_prefix = getenv( 'TABLE_PREFIX' );
+}
+
 add_action( 'altis.modules.init', function () {
 	$default_settings = [
 		'enabled'       => get_environment_type() !== 'production',


### PR DESCRIPTION
The WP CLI invocation was pointing to the wrong table prefix as it's run in a separate thread.