### PR TITLE
Allow Travis CI custom keys to override altis.yml

### DIFF
--- a/travis/project.yml
+++ b/travis/project.yml
@@ -3,5 +3,7 @@
 version: ~> 1.0
 import:
   # Commit reference is updated during composer dump-autoload
-  - humanmade/altis-dev-tools:travis/altis.yml@__ref_replace_me__
-  - .config/travis.yml
+  - source: humanmade/altis-dev-tools:travis/altis.yml@__ref_replace_me__
+    mode: deep_merge_append # Travis default merge type
+  - source: .config/travis.yml
+    mode: merge # Allows any customizations to override the altis.yml import settings


### PR DESCRIPTION
Ref:
• https://docs.travis-ci.com/user/build-config-imports/#merge-modes