### PR TITLE
WIP: Only build pull requests

### DIFF
--- a/travis/altis.yml
+++ b/travis/altis.yml
@@ -22,11 +22,7 @@ notifications:
     on_failure: change
 
 # Build on common default branches
-branches:
-  only:
-    - master
-    - develop
-    - development
+if: type = pull_request
 
 # Cache composer dependencies by default
 cache:

--- a/travis/altis.yml
+++ b/travis/altis.yml
@@ -21,7 +21,7 @@ notifications:
     on_success: never
     on_failure: change
 
-# Build on common default branches
+# Build on pull requests
 if: type = pull_request
 
 # Cache composer dependencies by default


### PR DESCRIPTION
This is an alternative approach to #49 

Using `if: type = pull_request` at the root level allows for overriding still but means regardless of the branch combination a build will be run for every pull request and avoids running for push events.

There might be use cases for running builds on push that I haven't yet considered so will do some more digging there.

cc @ntwb @stuartshields - any thoughts on this change?