### PR TITLE
Remove branch restrictions

### DIFF
--- a/docs/continuous-integration.md
+++ b/docs/continuous-integration.md
@@ -6,10 +6,12 @@ It is common practice to use some form of Continuous Integration service on proj
 
 A basic Travis configuration is installed automatically that imports the base Altis configuration and your own custom config file from `.config/travis.yml`.
 
+Configuration in `.config/travis.yml` will be merged into the Altis base config using a recursive-merge-append approach.
+
 The base configuration will run the following set up steps:
 
 - `composer install`
-- `composer local-server start`
+- `composer server start`
 
 From there the tests you run are up to you. A minimal example of your `.config/travis.yml` file might look like the following:
 
@@ -20,12 +22,34 @@ script:
 
 [See testing with PHPUnit for more information on the above command](./testing-with-phpunit.md).
 
+We recommend reading and bookmarking the following:
+
+- [Travis CI documentation](https://docs.travis-ci.com/)
+- [Travis config file reference](https://config.travis-ci.com/)
+
 Because there is a full instance of Altis running in the CI environment this enables the use of end to end testing using tools like the following:
 
 - [Puppeteer](https://pptr.dev/)
 - [Cypress](https://cypress.io)
 - [Lighthouse](https://developers.google.com/web/tools/lighthouse)
 - [aXe accessibility testing](https://www.deque.com/axe/)
+
+## Conditional Builds
+
+By default builds on Travis will run any time code is pushed to the repository or merged regardless of branch. You can use Travis' [conditional builds feature](https://docs.travis-ci.com/user/conditions-v1) to determine when a build should run. The following configuration examples show how to achieve some common set ups:
+
+```yaml
+# Only run on pull requests
+if: type = pull_request
+
+# Only run on specific branches (and pull requests to those branches)
+if: branch IN (staging, development)
+
+# Combining the above
+if: type = pull_request AND branch IN (staging, development)
+```
+
+There are many built in values and types of operator you can make use of in your config, as well as [setting conditions per stage for multistage builds](https://docs.travis-ci.com/user/build-stages/).
 
 ## Migrating From An Existing Travis Config
 
@@ -40,3 +64,11 @@ If you already have an existing Travis configuration then follow these steps:
 1. Confirm that the build works and tests pass
 
 Please contact support if you require any assistance with migrating.
+
+## Overriding The Base Config
+
+If you need to fully override the base config you can remove the line importing `humanmade/altis-dev-tools:travis/altis.yml` and committing the change. You can then add your full configuration to `.config/travis.yml`.
+
+**Note:** Altis will emit a warning on `composer install` or `composer update` if the `.travis.yml` doesn't match what's expected but no error codes are returned and you can safely ignore this.
+
+When overriding the base Travis config we cannot guarantee functionality within Travis or support any issues you may encounter.

--- a/travis/altis.yml
+++ b/travis/altis.yml
@@ -21,13 +21,6 @@ notifications:
     on_success: never
     on_failure: change
 
-# Build on common default branches
-branches:
-  only:
-    - master
-    - develop
-    - development
-
 # Cache composer dependencies by default
 cache:
   directories:


### PR DESCRIPTION
It's better to just be permissive here. Build on push is useful for ensuring the final version in `master` or a similar branch is fully working.

Supercedes #54 and #49 

To do:

- [x] Add docs & examples of config