### PR TITLE
Fix deprecated QM collector name function

### DIFF
--- a/inc/altis_config/class-qm-collector-altis-config.php
+++ b/inc/altis_config/class-qm-collector-altis-config.php
@@ -11,7 +11,4 @@ class QM_Collector_Altis_Config extends QM_Collector {
 
 	public $id = 'altis-config';
 
-	function name() {
-		return esc_html_x( 'Altis Config', 'Menu item name for the Query Monitor plugin', 'altis' );
-	}
 }

--- a/inc/altis_config/class-qm-output-html-altis-config.php
+++ b/inc/altis_config/class-qm-output-html-altis-config.php
@@ -17,6 +17,10 @@ class QM_Output_Html_Altis_Config extends QM_Output_Html {
 		add_filter( 'qm/output/menus', [ $this, 'admin_menu' ] );
 	}
 
+	public function name() {
+		return esc_html_x( 'Altis Config', 'Menu item name for the Query Monitor plugin', 'altis' );
+	}
+
 	public function output() {
 		$config = get_config()['modules'] ?? [];
 


### PR DESCRIPTION
The following warning was being generated after updating QM to 3.5:

```
Deprecated: Altis\Dev_Tools\Altis_Config\QM_Collector_Altis_Config::name() is deprecated since version 3.5! Use Altis\Dev_Tools\Altis_Config\QM_Output_Html_Altis_Config::name() instead.
```

This update moves the `name` method to the correct class.