### PR TITLE
Ensure constants are defined during install

### DIFF
--- a/inc/phpunit/bootstrap.php
+++ b/inc/phpunit/bootstrap.php
@@ -84,11 +84,6 @@ tests_add_filter( 'plugins_loaded', function () {
 	}
 }, 21 );
 
-/**
- * Modify the cache keys to prevent conflicts.
- */
-define( 'WP_CACHE_KEY_SALT', 'phpunit' );
-
 // Load custom bootstrap code.
 if ( file_exists( Altis\PHPUNIT_PROJECT_ROOT . '/.config/tests-bootstrap.php' ) ) {
 	require Altis\PHPUNIT_PROJECT_ROOT . '/.config/tests-bootstrap.php';

--- a/inc/phpunit/bootstrap.php
+++ b/inc/phpunit/bootstrap.php
@@ -49,7 +49,6 @@ tests_add_filter( 'upload_dir', function( $dir ) {
 /**
  * Setup ElasticPress on install.
  */
-define( 'EP_INDEX_PREFIX', 'tests_' );
 tests_add_filter( 'plugins_loaded', function () {
 	global $table_prefix;
 

--- a/inc/phpunit/config.php
+++ b/inc/phpunit/config.php
@@ -16,6 +16,9 @@ defined( 'WP_TESTS_DOMAIN' ) or define( 'WP_TESTS_DOMAIN', 'example.org' );
 defined( 'WP_TESTS_EMAIL' ) or define( 'WP_TESTS_EMAIL', 'admin@example.org' );
 defined( 'WP_TESTS_TITLE' ) or define( 'WP_TESTS_TITLE', 'Test Blog' );
 
+// Ensure cache key salt is different for test runs.
+defined( 'WP_CACHE_KEY_SALT' ) or define( 'WP_CACHE_KEY_SALT', 'phpunit' );
+
 // Ensure tests use their own ElasticPress indexes.
 defined( 'EP_INDEX_PREFIX' ) or define( 'EP_INDEX_PREFIX', 'tests_' );
 

--- a/inc/phpunit/config.php
+++ b/inc/phpunit/config.php
@@ -16,6 +16,9 @@ defined( 'WP_TESTS_DOMAIN' ) or define( 'WP_TESTS_DOMAIN', 'example.org' );
 defined( 'WP_TESTS_EMAIL' ) or define( 'WP_TESTS_EMAIL', 'admin@example.org' );
 defined( 'WP_TESTS_TITLE' ) or define( 'WP_TESTS_TITLE', 'Test Blog' );
 
+// Ensure tests use their own ElasticPress indexes.
+defined( 'EP_INDEX_PREFIX' ) or define( 'EP_INDEX_PREFIX', 'tests_' );
+
 // Set tests table prefix.
 $table_prefix = 'wptests_';
 


### PR DESCRIPTION
During the PHPUnit bootstrap process a separate process thread is run to install WP. This does not include the filters added in the bootstrap file or any constants defined there but it does include the tests config file.

This will prevent cache conflicts during test runs for local sites that lead to some undesirable behaviour such as redirecting the admin to example.org (or however WP_TEST_DOMAIN) is defined..