### PR TITLE
Dont disable QM error handler in cloud

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -9,7 +9,6 @@ namespace Altis\Dev_Tools;
 
 use const Altis\ROOT_DIR;
 use function Altis\get_config;
-use function Altis\get_environment_architecture;
 use QM_Collectors;
 
 /**

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -29,12 +29,6 @@ function on_plugins_loaded() {
 		return;
 	}
 
-	// In Cloud environments, disable the Query Monitor error handler
-	// as this will override our own error handler in Cloud.
-	if ( in_array( get_environment_architecture(), [ 'ec2', 'ecs' ], true ) ) {
-		define( 'QM_DISABLE_ERROR_HANDLER', true );
-	}
-
 	// Hide the db.php dropin installation warning and prompt.
 	add_filter( 'qm/show_extended_query_prompt', '__return_false' );
 	require_once ROOT_DIR . '/vendor/johnbillion/query-monitor/query-monitor.php';


### PR DESCRIPTION
This will no longer be needed as a workaround once the Cloud module update is rolled out to hook into the QM error handler action.

Related to #113