### PR TITLE
Updates Query Monitor to 3.6.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
 		]
 	},
 	"require": {
-		"johnbillion/query-monitor": "^3.5.2",
+		"johnbillion/query-monitor": "^3.6.7",
 		"altis/dev-tools-command": "^0.3.3",
 		"wp-phpunit/wp-phpunit": "5.6.0",
 		"phpunit/phpunit": "^7.1.4"


### PR DESCRIPTION
The package is also no longer abandoned on packagist so this checks off one item on the abandoned packages issue #81