### PR TITLE
Flush cache after test run

### DIFF
--- a/inc/phpunit/bootstrap.php
+++ b/inc/phpunit/bootstrap.php
@@ -99,3 +99,8 @@ require getenv( 'WP_PHPUNIT__DIR' ) . '/includes/bootstrap.php';
  * custom test case classes that extend WP_UnitTestCase.
  */
 do_action( 'altis.loaded_phpunit' );
+
+// Flush the cache.
+if ( function_exists( 'wp_cache_flush' ) ) {
+	wp_cache_flush();
+}


### PR DESCRIPTION
Fixes #132

Everything regarding the cache key was set correctly, there's some strange inner working of the WP install process that I had trouble understanding so just adding in this somewhat nuclear option. Does the job at least :/