### PR TITLE
Update wp-phpunit to 5.8.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
 	"require": {
 		"johnbillion/query-monitor": "^3.7.1",
 		"altis/dev-tools-command": "^0.4.0",
-		"wp-phpunit/wp-phpunit": "5.7.3",
+		"wp-phpunit/wp-phpunit": "5.8.1",
 		"phpunit/phpunit": "^7.5.20"
 	},
 	"extra": {


### PR DESCRIPTION
Changes: https://github.com/wp-phpunit/wp-phpunit/compare/5.7.3..5.8.1

Release post: https://make.wordpress.org/core/2021/09/27/changes-to-the-wordpress-core-php-test-suite/

I initially had a concern about the snake case changes, breaking any existing tests, but it seems like that's being introduced behind the scenes in a polyfill layer behind the WP_UnitTestCase_Base.

Fixes humanmade/altis-dev-tools#188