### PR TITLE
Update travis step to reflect escaped quotes properly

### DIFF
--- a/travis/module.yml
+++ b/travis/module.yml
@@ -62,7 +62,7 @@ before_script:
   - cd $HOME/test-root && cat <<< $(jq '. + {"extra":{"altis":{"modules":{"cms":{"default-theme":"test-theme"}}}}}' composer.json | jq . -) > composer.json
   # Require the current module and alias the branch to be tested to the target version main branch
   # Tricks composer to allow installing the branch version if a version constaint exists, by increasing the current patch version
-  - cd $HOME/test-root && composer require -W "$ALTIS_PACKAGE:dev-${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH} as `jq '.packages[] | select (.name==\"$ALTIS_PACKAGE\") | .version' composer.lock | sed -e 's/\"//g;/^dev/q;s/\$/9/'`"
+  - cd $HOME/test-root && composer require -W "$ALTIS_PACKAGE:dev-${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH} as `jq \".packages[] | select (.name==\\\"$ALTIS_PACKAGE\\\") | .version\" composer.lock | sed -e 's/\"//g;/^dev/q;s/\$/9/'`"
 
 script:
   # Start local server


### PR DESCRIPTION
Fixes an issue with quotes in the package installation step.

Ref https://github.com/humanmade/product-dev/issues/880