### PR TITLE
Update Travis build dist to Bionic

### DIFF
--- a/travis/module.yml
+++ b/travis/module.yml
@@ -1,6 +1,6 @@
 # Default Travis CI config for Altis
 os: linux
-dist: xenial
+dist: bionic
 
 # Ensure PHP CLI and Composer are available
 language: php


### PR DESCRIPTION
Xenial has problems with PHP 7.4 so no longer works for running tests. Bionic works properly and tests themselves are not impacted as they run in the containers.