### PR TITLE
Bump dev-tools-command to 0.6.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
 	},
 	"require": {
 		"johnbillion/query-monitor": "^3.9.0",
-		"altis/dev-tools-command": "^0.5.5",
+		"altis/dev-tools-command": "^0.6.0",
 		"wp-phpunit/wp-phpunit": "5.9.3",
 		"yoast/phpunit-polyfills": "^1.0.3",
 		"phpunit/phpunit": "^9.5.0",


### PR DESCRIPTION
The dev-tools-command package has been re-versioned as 0.6.0.