### PR TITLE
Allow phpunit/phpunit 9.5.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
 		"altis/dev-tools-command": "^0.5.4",
 		"wp-phpunit/wp-phpunit": "5.9.3",
 		"yoast/phpunit-polyfills": "^1.0.3",
-		"phpunit/phpunit": "^7.5.20",
+		"phpunit/phpunit": "^7.5.20 | ^9.5.0",
 		"lucatume/wp-browser": "~3.0.22",
 		"codeception/module-asserts": "~1.3.1",
 		"codeception/module-phpbrowser": "~1.0.3",


### PR DESCRIPTION
PHPUnit 7.5 does not support PHP 8.0 and dependency resolution fails when running under PHP 8.0. This commit allows v11 to use version 9.5 which supports PHP 8.0. Existing installations are not forced to upgrade.

This is a requirement for v11 + PHP 8.0 unit tests to run/succeed.