### PR TITLE
Load Query Monitor on an earlier hook

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -15,7 +15,7 @@ use QM_Collectors;
  * Bootstrap.
  */
 function bootstrap() {
-	add_action( 'plugins_loaded', __NAMESPACE__ . '\\on_plugins_loaded', 1 );
+	add_action( 'muplugins_loaded', __NAMESPACE__ . '\\on_plugins_loaded', 1 );
 }
 
 /**


### PR DESCRIPTION
Query Monitor should load as early as possible so it can capture as much data as possible. This is one of the reasons [QM attempts to force itself to the front of the list of active plugins](https://github.com/johnbillion/query-monitor/blob/9a7600f3990710807c300079ad286c445f69fd83/classes/Activation.php#L72-L117) on a regular WordPress installation.

On Altis, QM doesn't load until the `plugins_loaded` hook. This means other plugins can perform actions such as triggering errors and performing database queries before QM has loaded, and then it either doesn't catch them or can only see limited information because it hasn't had a chance to put its own collectors in place which log stack traces too.

This change moves the loading of QM onto the `muplugins_loaded` hook. There are some earlier hooks such as `ms_loaded` but not all the required API functions are available at this point.