### PR TITLE
Add QA Test for Altis Dev Tools.

### DIFF
--- a/tests/acceptance/DevToolsCest.php
+++ b/tests/acceptance/DevToolsCest.php
@@ -7,7 +7,7 @@
 use Codeception\Util\Locator;
 
 /**
- * Test query monitor and it's tabs render correctly.
+ * Test Query Monitor and it's tabs render correctly.
  */
 class DevToolsCest {
 
@@ -21,23 +21,23 @@ class DevToolsCest {
 		$I->loginAsAdmin();
 		$I->amOnAdminPage( '/' );
 
-		// See the query monitor link in menu.
+		// See the Query Monitor link in menu.
 		$I->moveMouseOver( '#wp-admin-bar-query-monitor' );
 
-		// Test and confirm the Altis Config tab renders, using the module column name.
+		// Test and confirm the Altis Config tab and content renders, using the "Module" column heading.
 		$I->seeLink( 'Altis Config' );
 		$I->click( 'Altis Config' );
 		$I->see( 'Module', 'th' );
 
-		// Test and confirm the Hooks & Actions Tab.
+		// Test and confirm the Hooks & Actions tab and content renders, using the "Action" column heading.
 		$I->click( Locator::find( 'button', ['data-qm-href' => '#qm-hooks'] ) );
 		$I->see( 'Action', 'th' );
 
-		// Test and confirm the ElasticPress Tab.
+		// Test and confirm the ElasticPress tab and content renders, using the "Total ElasticPress Queries" span.
 		$I->click( Locator::find( 'button', ['data-qm-href' => '#qm-debug_bar_ep_debug_bar_elasticpress'] ) );
 		$I->see( 'Total ElasticPress Queries:', 'span' );
 
-		// Test and confrim AWS X-Ray tab,
+		// Test and confrim AWS X-Ray tab and content renders, using the "Segment Name" column heading.
 		$I->click( Locator::find( 'button', ['data-qm-href' => '#qm-aws-xray'] ) );
 		$I->see( 'Segment Name', 'th' );
 	}

--- a/tests/acceptance/DevToolsCest.php
+++ b/tests/acceptance/DevToolsCest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Tests for Altis Dev Tools Module.
+ * Tests for the Altis Dev Tools Module.
  *
  * phpcs:disable WordPress.Files, WordPress.NamingConventions, PSR1.Classes.ClassDeclaration.MissingNamespace, HM.Functions.NamespacedFunctions
  */
@@ -41,7 +41,7 @@ class DevToolsCest {
 	}
 
 	/**
-	 * Open Query Monitor / Dev Tools panel and check all tabs are working.
+	 * Open Query Monitor / Dev Tools panel and check tabs are working.
 	 *
 	 * @param AcceptanceTester $I Tester
 	 */
@@ -53,7 +53,7 @@ class DevToolsCest {
 		// See the Query Monitor link in menu.
 		$I->moveMouseOver( '#wp-admin-bar-query-monitor' );
 
-		// Test and confirm the Altis Config tab and content renders, using the "Module" column heading.
+		// Check the Altis Config tab and content renders, using the "Module" column heading.
 		$I->seeLink( 'Altis Config' );
 		$I->click( 'Altis Config' );
 		$I->see( 'Module', 'th' );

--- a/tests/acceptance/DevToolsCest.php
+++ b/tests/acceptance/DevToolsCest.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Tests for Altis Dev Tools Module.
+ *
+ * phpcs:disable WordPress.Files, WordPress.NamingConventions, PSR1.Classes.ClassDeclaration.MissingNamespace, HM.Functions.NamespacedFunctions
+ */
+use Codeception\Util\Locator;
+
+/**
+ * Test query monitor and it's tabs render correctly.
+ */
+class DevToolsCest {
+
+	/**
+	 * Open Query Monitor / Dev Tools panel and check all tabs are working.
+	 *
+	 * @param AcceptanceTester $I Tester
+	 */
+	public function testQueryMonitor( AcceptanceTester $I ) {
+		$I->wantToTest( 'Open Query Monitor / Dev Tools panel and check all tabs are working.' );
+		$I->loginAsAdmin();
+		$I->amOnAdminPage( '/' );
+
+		// See the query monitor link in menu.
+		$I->moveMouseOver( '#wp-admin-bar-query-monitor' );
+
+		// Test and confirm the Altis Config tab renders, using the module column name.
+		$I->seeLink( 'Altis Config' );
+		$I->click( 'Altis Config' );
+		$I->see( 'Module', 'th' );
+
+		// Test and confirm the Hooks & Actions Tab.
+		$I->click( Locator::find( 'button', ['data-qm-href' => '#qm-hooks'] ) );
+		$I->see( 'Action', 'th' );
+
+		// Test and confirm the ElasticPress Tab.
+		$I->click( Locator::find( 'button', ['data-qm-href' => '#qm-debug_bar_ep_debug_bar_elasticpress'] ) );
+		$I->see( 'Total ElasticPress Queries:', 'span' );
+
+		// Test and confrim AWS X-Ray tab,
+		$I->click( Locator::find( 'button', ['data-qm-href' => '#qm-aws-xray'] ) );
+		$I->see( 'Segment Name', 'th' );
+	}
+
+}

--- a/tests/acceptance/DevToolsCest.php
+++ b/tests/acceptance/DevToolsCest.php
@@ -12,6 +12,35 @@ use Codeception\Util\Locator;
 class DevToolsCest {
 
 	/**
+	 * Rollback callback for the Dev Tools activation bootstrap call.
+	 *
+	 * @var callable
+	 */
+	protected $rollback = null;
+
+	/**
+	 * Make sure Dev Tools is activated.
+	 *
+	 * @param AcceptanceTester $I Actor object.
+	 *
+	 * @return void
+	 */
+	public function _before( AcceptanceTester $I ) {
+		$this->rollback = $I->bootstrapWith( [ __CLASS__, '_enableDevTools' ] );
+	}
+
+	/**
+	 * Deactivate Dev Tools after tests are finished.
+	 *
+	 * @param AcceptanceTester $I Actor object.
+	 *
+	 * @return void
+	 */
+	public function _after( AcceptanceTester $I ) {
+		call_user_func( $this->rollback );
+	}
+
+	/**
 	 * Open Query Monitor / Dev Tools panel and check all tabs are working.
 	 *
 	 * @param AcceptanceTester $I Tester
@@ -40,6 +69,18 @@ class DevToolsCest {
 		// Test and confrim AWS X-Ray tab and content renders, using the "Segment Name" column heading.
 		$I->click( Locator::find( 'button', ['data-qm-href' => '#qm-aws-xray'] ) );
 		$I->see( 'Segment Name', 'th' );
+	}
+
+	/**
+	 * Activate Dev Tools.
+	 *
+	 * @return void
+	 */
+	public static function _enableDevTools() {
+		add_filter( 'altis.config', function( $config ) {
+			$config['modules']['dev-tools']['enabled'] = true;
+			return $config;
+		} );
 	}
 
 }


### PR DESCRIPTION
Related issue - https://github.com/humanmade/product-dev/issues/836

Command to run the test manually - `composer dev-tools codecept -p packages/dev-tools/tests run`

Test confirms:

1. `Query Monitor` link in menu can be seen.
2. `Altis Config` tab works and renders content.
3. `Hooks & Actions` tab works and renders content.
4. `ElasticPress` tab works and renders content.
5. `AWS X-Ray` tab works and renders content.