### PR TITLE
Ignore wp-phpunit dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
   directory: "/"
   schedule:
     interval: weekly
+  ignore:
+    - dependency-name: 	"wp-phpunit/wp-phpunit"
   open-pull-requests-limit: 10
   allow:
   - dependency-type: "direct"
@@ -12,6 +14,8 @@ updates:
   directory: "/"
   schedule:
     interval: weekly
+  ignore:
+    - dependency-name: 	"wp-phpunit/wp-phpunit"
   open-pull-requests-limit: 10
   allow:
   - dependency-type: "direct"
@@ -21,6 +25,8 @@ updates:
   directory: "/"
   schedule:
     interval: weekly
+  ignore:
+    - dependency-name: 	"wp-phpunit/wp-phpunit"
   open-pull-requests-limit: 10
   allow:
   - dependency-type: "direct"
@@ -30,6 +36,8 @@ updates:
   directory: "/"
   schedule:
     interval: weekly
+  ignore:
+    - dependency-name: 	"wp-phpunit/wp-phpunit"
   open-pull-requests-limit: 10
   allow:
   - dependency-type: "direct"
@@ -39,6 +47,8 @@ updates:
   directory: "/"
   schedule:
     interval: weekly
+  ignore:
+    - dependency-name: 	"wp-phpunit/wp-phpunit"
   open-pull-requests-limit: 10
   allow:
   - dependency-type: "direct"


### PR DESCRIPTION
Exclude `wp-phpunit` from Dependabot checking.