### PR TITLE
Fixes the composer.json patching to use the correct jq syntax.

### DIFF
--- a/travis/module.yml
+++ b/travis/module.yml
@@ -59,9 +59,9 @@ before_script:
   # Install Altis test theme package
   - cd $HOME/test-root && composer require altis/test-theme --ignore-platform-req=php+ --ignore-platform-req=ext-*
   # Mark the test theme as the default
-  - cd $HOME/test-root && cat <<< $(jq '. + {"extra":{"altis":{"modules":{"cms":{"default-theme":"test-theme"}}}}}' composer.json | jq . -) > composer.json
+  - cd $HOME/test-root && cat <<< $(jq '. * {"extra":{"altis":{"modules":{"cms":{"default-theme":"test-theme"}}}}}' composer.json | jq . -) > composer.json
   # Require the current module and alias the branch to be tested to the target version main branch
-  # Tricks composer to allow installing the branch version if a version constaint exists, by increasing the current patch version
+  # Tricks composer to allow installing the branch version if a version constraint exists, by increasing the current patch version
   - cd $HOME/test-root && composer require -W "$ALTIS_PACKAGE:dev-${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH} as `jq \".packages[] | select (.name==\\\"$ALTIS_PACKAGE\\\") | .version\" composer.lock | sed -e 's/\"//g;/^dev/q;s/\$/9/'`"
 
 script:


### PR DESCRIPTION
Fixes https://github.com/humanmade/product-dev/issues/1437

Before, the difference after running the command looked like this:

```shell
$ git diff --no-index -w -b composer.json.saved composer.json
diff --git a/composer.json.saved b/composer.json
index 93b65fb..6bc2053 100644
--- a/composer.json.saved
+++ b/composer.json
@@ -17,16 +17,12 @@
   ],
   "minimum-stability": "dev",
   "extra": {
-        "installer-paths": {
-            "content/mu-plugins/{$name}/": [
-                "type:wordpress-muplugin"
-            ],
-            "content/plugins/{$name}/": [
-                "type:wordpress-plugin"
-            ],
-            "content/themes/{$name}/": [
-                "type:wordpress-theme"
-            ]
+    "altis": {
+      "modules": {
+        "cms": {
+          "default-theme": "test-theme"
+        }
+      }
     }
   },
   "config": {
```

After this change, it looks like this:

```shell
diff --git a/composer.json.saved b/composer.json
index 93b65fb..cf70f1e 100644
--- a/composer.json.saved
+++ b/composer.json
@@ -27,6 +27,13 @@
       "content/themes/{$name}/": [
         "type:wordpress-theme"
       ]
+    },
+    "altis": {
+      "modules": {
+        "cms": {
+          "default-theme": "test-theme"
+        }
+      }
     }
   },
   "config": {
```