### PR TITLE
Manually update wp-phpunit to match WordPress version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
 	"require": {
 		"johnbillion/query-monitor": "^3.13.1",
 		"altis/dev-tools-command": "^0.7.2",
-		"wp-phpunit/wp-phpunit": "6.2.2",
+		"wp-phpunit/wp-phpunit": "6.3.1",
 		"yoast/phpunit-polyfills": "^1.0.5",
 		"phpunit/phpunit": "^9.5.0",
 		"lucatume/wp-browser": "~3.1.5",


### PR DESCRIPTION
Needed for v17 release https://github.com/humanmade/product-dev/issues/1452
Related to https://github.com/humanmade/altis-cms/pull/741
