### PR TITLE
Remove v15-branch from checks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -54,14 +54,3 @@ updates:
   - dependency-type: "direct"
   versioning-strategy: "increase"
   target-branch: v16-branch
-- package-ecosystem: composer
-  directory: "/"
-  schedule:
-    interval: weekly
-  ignore:
-    - dependency-name: "wp-phpunit/wp-phpunit"
-  open-pull-requests-limit: 10
-  allow:
-  - dependency-type: "direct"
-  versioning-strategy: "increase"
-  target-branch: v15-branch


### PR DESCRIPTION
Remove EOL v15 branch from dependabot checks.

Fixes https://github.com/humanmade/product-dev/issues/1582