### PR TITLE
Fix Failing build  on PHP version mismatch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 # Import Travis configuration from dev-tools repo
 version: ~> 1.0
 import:
-  - source: humanmade/altis-dev-tools:travis/module.yml@0bfa112a
+  - source: humanmade/altis-dev-tools:travis/module.yml@f45c03b0
     mode: deep_merge_append
 
 # Add your custom config below, which will merge with the default module config from the section above.

--- a/travis/module.yml
+++ b/travis/module.yml
@@ -54,8 +54,14 @@ branches:
     - travis.*
 
 before_script:
-  # Install Altis and start the local server
-  - composer create-project altis/skeleton:dev-$TRAVIS_BRANCH --stability=dev --ignore-platform-req=php+ --ignore-platform-req=ext-* $HOME/test-root || composer create-project altis/skeleton:dev-master --stability=dev --ignore-platform-req=php+ --ignore-platform-req=ext-* $HOME/test-root || exit 1
+  # Figure out the base branch or default to `master`
+  - '[[ $TRAVIS_BRANCH =~ (v[0-9]{2}-branch) ]] && BASE_BRANCH="${BASH_REMATCH[1]}" || BASE_BRANCH="dev-master"'
+  - export BASE_BRANCH
+  # Install Altis, using this PR branch or the calculated value above
+  - |
+    composer create-project altis/skeleton:dev-$TRAVIS_BRANCH --stability=dev --ignore-platform-req=php+ --ignore-platform-req=ext-* $HOME/test-root || \
+    composer create-project altis/skeleton:dev-$BASE_BRANCH --stability=dev --ignore-platform-req=php+ --ignore-platform-req=ext-* $HOME/test-root || \
+    exit 1
   # Install Altis test theme package
   - cd $HOME/test-root && composer require altis/test-theme --ignore-platform-req=php+ --ignore-platform-req=ext-*
   # Mark the test theme as the default
@@ -78,5 +84,6 @@ script:
   - cd $HOME/test-root && composer server start
   # Run Codeception for module tests, if test suites are found.
   - cd $HOME/test-root && composer dev-tools codecept run -p vendor/$ALTIS_PACKAGE/tests
+  # Initialise and run documentation lint config
   - cd $HOME/test-root && composer dev-tools bootstrap lintdocs
   - cd $HOME/test-root && composer dev-tools lintdocs -l vendor/$ALTIS_PACKAGE all


### PR DESCRIPTION
Calculate the release branch or fall back to master. That way, older branches do not try to checkout master which now requires PHP8.2. Add some more comments
Reformat for readability.

Addresses https://github.com/humanmade/product-dev/issues/1624