### PR TITLE
Fixes codeception dependency.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
 		"codeception/module-filesystem": "~3.0",
 		"codeception/module-cli": "~2.0",
 		"codeception/util-universalframework": "~1.0",
-		"codeception/codeception": "~5.2"
+		"codeception/codeception": "~5.1.2"
   },
 	"extra": {
 		"altis": {


### PR DESCRIPTION
Codeception/Codeception introduced an alias for version 5.2 as dev-main,. https://github.com/Codeception/Codeception/pull/6787 This was inadvertently causing a problem with the minimum-stability setting in composer.json. This change fixes that.