### PR TITLE
Upgrade wp-pphunit to 6.7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
 	"require": {
 		"johnbillion/query-monitor": "^3.16.3",
 		"altis/dev-tools-command": "^0.8.0",
-		"wp-phpunit/wp-phpunit": "6.6.1",
+		"wp-phpunit/wp-phpunit": "6.7.0",
 		"yoast/phpunit-polyfills": "^2.0.1",
 		"phpunit/phpunit": "~9.6",
 		"lucatume/wp-browser": "~4.2.0",


### PR DESCRIPTION
This upgrades wp-phpunit/wp-phpunit to match WordPress version 6.7.0.

Addresses https://github.com/humanmade/product-dev/issues/1619
