### PR TITLE
Update dependabot for v21 release

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,17 @@ updates:
   allow:
   - dependency-type: "direct"
   versioning-strategy: "increase"
+  target-branch: v21-branch
+- package-ecosystem: composer
+  directory: "/"
+  schedule:
+    interval: weekly
+  ignore:
+    - dependency-name: "wp-phpunit/wp-phpunit"
+  open-pull-requests-limit: 10
+  allow:
+  - dependency-type: "direct"
+  versioning-strategy: "increase"
   target-branch: v20-branch
 - package-ecosystem: composer
   directory: "/"
@@ -43,14 +54,3 @@ updates:
   - dependency-type: "direct"
   versioning-strategy: "increase"
   target-branch: v18-branch
-- package-ecosystem: composer
-  directory: "/"
-  schedule:
-    interval: weekly
-  ignore:
-    - dependency-name: "wp-phpunit/wp-phpunit"
-  open-pull-requests-limit: 10
-  allow:
-  - dependency-type: "direct"
-  versioning-strategy: "increase"
-  target-branch: v17-branch


### PR DESCRIPTION
Update dependabot for v21 release.
Remove v17 release.

Addresses https://github.com/humanmade/product-dev/issues/1647
