### PR TITLE
Update dependabot for v22 release

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,6 @@ updates:
   directory: "/"
   schedule:
     interval: weekly
-  ignore:
-    - dependency-name: "wp-phpunit/wp-phpunit"
   open-pull-requests-limit: 10
   allow:
   - dependency-type: "direct"
@@ -14,8 +12,15 @@ updates:
   directory: "/"
   schedule:
     interval: weekly
-  ignore:
-    - dependency-name: "wp-phpunit/wp-phpunit"
+  open-pull-requests-limit: 10
+  allow:
+  - dependency-type: "direct"
+  versioning-strategy: "increase"
+  target-branch: v22-branch
+- package-ecosystem: composer
+  directory: "/"
+  schedule:
+    interval: weekly
   open-pull-requests-limit: 10
   allow:
   - dependency-type: "direct"
@@ -25,8 +30,6 @@ updates:
   directory: "/"
   schedule:
     interval: weekly
-  ignore:
-    - dependency-name: "wp-phpunit/wp-phpunit"
   open-pull-requests-limit: 10
   allow:
   - dependency-type: "direct"
@@ -36,21 +39,8 @@ updates:
   directory: "/"
   schedule:
     interval: weekly
-  ignore:
-    - dependency-name: "wp-phpunit/wp-phpunit"
   open-pull-requests-limit: 10
   allow:
   - dependency-type: "direct"
   versioning-strategy: "increase"
   target-branch: v19-branch
-- package-ecosystem: composer
-  directory: "/"
-  schedule:
-    interval: weekly
-  ignore:
-    - dependency-name: "wp-phpunit/wp-phpunit"
-  open-pull-requests-limit: 10
-  allow:
-  - dependency-type: "direct"
-  versioning-strategy: "increase"
-  target-branch: v18-branch

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
   directory: "/"
   schedule:
     interval: weekly
+  ignore:
+    - dependency-name: "wp-phpunit/wp-phpunit"
   open-pull-requests-limit: 10
   allow:
   - dependency-type: "direct"
@@ -12,6 +14,8 @@ updates:
   directory: "/"
   schedule:
     interval: weekly
+  ignore:
+    - dependency-name: "wp-phpunit/wp-phpunit"
   open-pull-requests-limit: 10
   allow:
   - dependency-type: "direct"
@@ -21,6 +25,8 @@ updates:
   directory: "/"
   schedule:
     interval: weekly
+  ignore:
+    - dependency-name: "wp-phpunit/wp-phpunit"
   open-pull-requests-limit: 10
   allow:
   - dependency-type: "direct"
@@ -30,6 +36,8 @@ updates:
   directory: "/"
   schedule:
     interval: weekly
+  ignore:
+    - dependency-name: "wp-phpunit/wp-phpunit"
   open-pull-requests-limit: 10
   allow:
   - dependency-type: "direct"
@@ -39,6 +47,8 @@ updates:
   directory: "/"
   schedule:
     interval: weekly
+  ignore:
+    - dependency-name: "wp-phpunit/wp-phpunit"
   open-pull-requests-limit: 10
   allow:
   - dependency-type: "direct"


### PR DESCRIPTION
- Update dependabot for v22 release.
- Remove v17 release.

- Delivers https://github.com/humanmade/product-dev/issues/1696