### PR TITLE
Pin behat/gherkin to non-broken version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,8 @@
 		"codeception/module-filesystem": "~3.0",
 		"codeception/module-cli": "~2.0",
 		"codeception/util-universalframework": "~1.0",
-		"codeception/codeception": "~5.1.2"
+		"codeception/codeception": "~5.1.2",
+		"behat/gherkin": "~4.10.0"
   },
 	"extra": {
 		"altis": {


### PR DESCRIPTION
The latest version of `behat/gherkin` (as required indirectly by codeception) is broken, so we need to pin it to a non-broken version.

```
Warning: require(/usr/src/app/vendor/behat/gherkin/src/../../../i18n.php): Failed to open stream: No such file or directory in /usr/src/app/vendor/codeception/codeception/src/Codeception/Test/Loader/Gherkin.php on line 78

Fatal error: Uncaught Error: Failed opening required '/usr/src/app/vendor/behat/gherkin/src/../../../i18n.php' (include_path='.:/usr/local/lib/php') in /usr/src/app/vendor/codeception/codeception/src/Codeception/Test/Loader/Gherkin.php:78
Stack trace:
  thrown in /usr/src/app/vendor/codeception/codeception/src/Codeception/Test/Loader/Gherkin.php on line 78
```

See Codeception issue here https://github.com/Codeception/Codeception/issues/6833