### PR TITLE
Upgrade to WordPress 6.8 compatible

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
 	"require": {
 		"johnbillion/query-monitor": "^3.17.2",
 		"altis/dev-tools-command": "^0.8.1",
-		"wp-phpunit/wp-phpunit": "6.7.0",
+		"wp-phpunit/wp-phpunit": "6.8.0",
 		"yoast/phpunit-polyfills": "^4.0.0",
 		"phpunit/phpunit": "~9.6",
 		"lucatume/wp-browser": "~4.4.2",

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
 	"require": {
 		"johnbillion/query-monitor": "^3.17.2",
 		"altis/dev-tools-command": "^0.8.1",
-		"wp-phpunit/wp-phpunit": "6.8.0",
+		"wp-phpunit/wp-phpunit": "6.8.1",
 		"yoast/phpunit-polyfills": "^4.0.0",
 		"phpunit/phpunit": "~9.6",
 		"lucatume/wp-browser": "~4.4.2",


### PR DESCRIPTION
Upgrades to use WordPress 6.8 compatible wp-phpunit library.

Addresses: https://github.com/humanmade/product-dev/issues/1768