### PR TITLE
Update Dependabot for v24 release

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,17 @@ updates:
     - dependency-name: "wp-phpunit/wp-phpunit"
   open-pull-requests-limit: 10
   allow:
+    - dependency-type: "direct"
+  versioning-strategy: "increase"
+  target-branch: v24-branch
+- package-ecosystem: composer
+  directory: "/"
+  schedule:
+    interval: weekly
+  ignore:
+    - dependency-name: "wp-phpunit/wp-phpunit"
+  open-pull-requests-limit: 10
+  allow:
   - dependency-type: "direct"
   versioning-strategy: "increase"
   target-branch: v23-branch


### PR DESCRIPTION
This PR updates Dependabot configuration to add the v24 branch.
Addresses https://github.com/humanmade/product-dev/issues/1827