### PR TITLE
Fix reindexContent to use correct environment variable

### DIFF
--- a/tests/_support/AcceptanceTester.php
+++ b/tests/_support/AcceptanceTester.php
@@ -75,10 +75,22 @@ class AcceptanceTester extends \Codeception\Actor
 	 * @return void
 	 */
 	public function reindexContent( string $options = '' ) {
+		// Get URL from environment or fallback to reading from codeception.env file.
+		$url = getenv( 'TEST_SITE_WP_URL' );
+		if ( empty( $url ) ) {
+			$env_file = \Codeception\Configuration::projectDir() . 'codeception.env';
+			if ( file_exists( $env_file ) ) {
+				$contents = file_get_contents( $env_file );
+				if ( preg_match( '/^TEST_SITE_WP_URL=(.+)$/m', $contents, $matches ) ) {
+					$url = trim( $matches[1] );
+				}
+			}
+		}
+
 		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.system_calls_exec
 		exec( sprintf(
 			'WPBROWSER_HOST_REQUEST=1 wp elasticpress sync --network-wide --setup --yes --url=%s %s',
-			getenv( 'TEST_SITE_WP_DOMAIN' ),
+			$url,
 			$options
 		), $output );
 	}

--- a/tests/_support/_generated/AcceptanceTesterActions.php
+++ b/tests/_support/_generated/AcceptanceTesterActions.php
@@ -1,4 +1,4 @@
-<?php  //[STAMP] 0a5fbc61a1d6a7fe3afd3703c550e015
+<?php  //[STAMP] 0986a831d9f2e8b79195c0e4276a17ec
 // phpcs:ignoreFile
 namespace _generated;
 
@@ -8147,7 +8147,7 @@ trait AcceptanceTesterActions
     /**
      * [!] Method is generated. Documentation taken from corresponding module.
      *
-     * Go to a page in the admininstration area of the site.
+     * Go to a page in the administration area of the site.
      *
      * This method will **not** handle authentication to the administration area.
      *

--- a/tests/_support/_generated/FunctionalTesterActions.php
+++ b/tests/_support/_generated/FunctionalTesterActions.php
@@ -1,4 +1,4 @@
-<?php  //[STAMP] 76cb38b1e5922a5be98081e03aa1eadf
+<?php  //[STAMP] 163243aacda7eb6a153e2975f0ad9cb0
 // phpcs:ignoreFile
 namespace _generated;
 
@@ -7442,7 +7442,7 @@ trait FunctionalTesterActions
     /**
      * [!] Method is generated. Documentation taken from corresponding module.
      *
-     * Go to a page in the admininstration area of the site.
+     * Go to a page in the administration area of the site.
      *
      * This method will **not** handle authentication to the administration area.
      *


### PR DESCRIPTION
Update AcceptanceTester::reindexContent() to use TEST_SITE_WP_URL instead of TEST_SITE_WP_DOMAIN. Add fallback logic to read from codeception.env file when environment variable is not set.

- fixes https://github.com/humanmade/product-dev/issues/1816