### PR TITLE
Add reusable GitHub Actions workflows for module CI

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,86 @@
+# Altis GitHub Actions CI Configuration
+
+This folder contains the **reusable workflows** that Altis modules use for CI on GitHub Actions. They replace the Travis CI templates that previously lived in `travis/`.
+
+## Workflows
+
+### `module-ci.yml` — replaces `travis/module.yml`
+
+Used by every Altis module repo (`altis-cms`, `altis-media`, `altis-core`, …). Builds an Altis skeleton project, injects the package under test, starts local-server, and runs the Codeception or PHPUnit suite plus docs linting.
+
+### `altis-ci.yml` — replaces `travis/altis.yml`
+
+Used by the skeleton/`empty` package, where the repo *is* the Altis project (rather than a module installed into one). Just runs `composer install`, starts local-server, and runs tests.
+
+## Calling the reusable workflow
+
+Each module repo holds a thin caller at `.github/workflows/ci.yml`:
+
+```yaml
+name: CI
+on:
+  push:
+    branches: [master, main, 'v*-branch']
+  pull_request:
+    branches: [master, main, 'v*-branch']
+
+jobs:
+  ci:
+    uses: humanmade/altis-dev-tools/.github/workflows/module-ci.yml@<sha>
+    with:
+      altis-package: altis/cms          # the composer name
+      # test-command: phpunit          # default is 'codecept'
+      # lint-docs: false               # default is true
+    secrets:
+      DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+      DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+```
+
+Pin to a SHA from this repo (mirrors the `travis/module.yml@<sha>` pattern). The bulk-update helper at `humanmade/altis/scripts/update-module-gha-ref.sh` opens PRs across module repos to bump the SHA.
+
+## Inputs
+
+`module-ci.yml`:
+
+| Input | Default | Notes |
+| --- | --- | --- |
+| `altis-package` | *(required)* | Composer name (e.g. `altis/cms`). Used to install the package and locate its tests under `vendor/<altis-package>/tests`. |
+| `php-version` | `8.3` | |
+| `node-version` | `24` | |
+| `test-command` | `codecept` | Set to `phpunit` for `altis-dev-tools` itself. |
+| `lint-docs` | `true` | Run `dev-tools lintdocs` after tests. |
+| `runs-on` | `ubuntu-22.04` | Matches Travis `dist: jammy`. |
+
+`altis-ci.yml`:
+
+| Input | Default |
+| --- | --- |
+| `php-version` | `8.3` |
+| `node-version` | `24` |
+| `test-command` | `phpunit` |
+| `runs-on` | `ubuntu-22.04` |
+
+## Required secrets (per caller repo)
+
+- `DOCKER_USERNAME` — Docker Hub user (typically `altis`)
+- `DOCKER_PASSWORD` — Docker Hub access token
+
+These are the same secrets the previous Travis builds used. Verify with `gh secret list -R humanmade/<repo>`.
+
+## Phases (mirrors the previous Travis flow)
+
+The `module-ci.yml` test job:
+
+1. Determine the base branch — match `vNN-branch` against the trigger ref, otherwise fall back to `dev-master`.
+2. `composer create-project altis/skeleton:dev-<branch>` into `$HOME/test-root` (with the base branch as a fallback).
+3. `composer require altis/test-theme` and set it as the default theme.
+4. `composer require <altis-package>:dev-<branch> as <aliased-version>` to inject the package being tested over any version constraint.
+5. Generate `.config/salts.php` from the WordPress salts API and append a load guard to `.config/load.php`.
+6. `composer server start`.
+7. `composer dev-tools codecept run -p vendor/<altis-package>/tests` (or `phpunit`).
+8. `composer dev-tools bootstrap lintdocs` + `composer dev-tools lintdocs -l vendor/<altis-package> all`.
+9. On failure, upload Codeception output as a workflow artifact (named `codecept-output-<package>-php<version>`).
+
+## Skipping when there are no tests
+
+The `detect-tests` job checks for `tests/*.suite.yml` files. If none exist, the `test` job is skipped — same early-exit behaviour as the Travis `before_install` check.

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -10,7 +10,9 @@ Used by every Altis module repo (`altis-cms`, `altis-media`, `altis-core`, …).
 
 ### `altis-ci.yml` — replaces `travis/altis.yml`
 
-Used by the skeleton/`empty` package, where the repo *is* the Altis project (rather than a module installed into one). Just runs `composer install`, starts local-server, and runs tests.
+Used by the skeleton/`empty` package and by end-user Altis projects, where the repo *is* the Altis project (rather than a module installed into one). Just runs `composer install`, starts local-server, and runs tests.
+
+The thin caller for end-user projects is shipped as the template at [`templates/project-ci.yml`](../../templates/project-ci.yml). The `altis/dev-tools-command` composer plugin copies it to `.github/workflows/ci.yml` on `composer create-project altis/skeleton` and re-pins the `@<ref>` to the installed dev-tools version on every `composer install` / `composer update` (until the user customises the file).
 
 ## Calling the reusable workflow
 

--- a/.github/workflows/altis-ci.yml
+++ b/.github/workflows/altis-ci.yml
@@ -1,0 +1,90 @@
+name: Altis CI
+
+# Reusable workflow for the Altis skeleton/empty package, where the repo IS the
+# composer project (rather than a module installed into the skeleton).
+# Replaces travis/altis.yml + the .config/travis.yml override.
+
+on:
+  workflow_call:
+    inputs:
+      php-version:
+        default: '8.3'
+        type: string
+      node-version:
+        default: '24'
+        type: string
+      test-command:
+        description: "'phpunit' (default) or 'codecept'."
+        default: 'phpunit'
+        type: string
+      runs-on:
+        default: 'ubuntu-22.04'
+        type: string
+    secrets:
+      DOCKER_USERNAME:
+        required: true
+      DOCKER_PASSWORD:
+        required: true
+
+jobs:
+  test:
+    runs-on: ${{ inputs.runs-on }}
+    env:
+      COMPOSE_HTTP_TIMEOUT: '360'
+      ES_MEM_LIMIT: '2g'
+      COMPOSER_NO_INTERACTION: '1'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ inputs.php-version }}
+          tools: composer:v2
+          coverage: none
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ inputs.node-version }}
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.composer/cache
+          key: composer-${{ runner.os }}-php${{ inputs.php-version }}-${{ hashFiles('composer.json', 'composer.lock') }}
+          restore-keys: |
+            composer-${{ runner.os }}-php${{ inputs.php-version }}-
+
+      - name: Authenticate with Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Composer install
+        run: composer install
+
+      - name: Start local server
+        run: composer local-server start
+
+      - name: Run tests
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${{ inputs.test-command }}" = "codecept" ]; then
+            composer dev-tools codecept run
+          else
+            composer dev-tools phpunit
+          fi
+
+      - name: Upload test output on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: altis-ci-output-php${{ inputs.php-version }}
+          path: |
+            tests/_output/
+            .tests/_output/
+          if-no-files-found: ignore
+          retention-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+# Caller for the reusable Module CI workflow.
+# After the reusable workflow lands on master, bump `@master` to a pinned SHA via
+# scripts/update-module-gha-ref.sh.
+
+on:
+  push:
+    branches:
+      - master
+      - main
+      - 'v*-branch'
+  pull_request:
+    branches:
+      - master
+      - main
+      - 'v*-branch'
+
+jobs:
+  ci:
+    uses: humanmade/altis-dev-tools/.github/workflows/module-ci.yml@master
+    with:
+      altis-package: altis/dev-tools
+      test-command: phpunit
+    secrets:
+      DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+      DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/module-ci.yml
+++ b/.github/workflows/module-ci.yml
@@ -1,0 +1,212 @@
+name: Module CI
+
+# Reusable workflow for Altis module CI.
+# Replaces travis/module.yml. Each module adds a thin caller at
+# .github/workflows/ci.yml that invokes this with `uses: humanmade/altis-dev-tools/.github/workflows/module-ci.yml@<sha>`.
+
+on:
+  workflow_call:
+    inputs:
+      altis-package:
+        description: 'Composer name of the package under test (e.g. altis/cms).'
+        required: true
+        type: string
+      php-version:
+        description: 'PHP version for the runner.'
+        default: '8.3'
+        type: string
+      node-version:
+        description: 'Node.js version for the runner.'
+        default: '24'
+        type: string
+      test-command:
+        description: "'codecept' (default) or 'phpunit'."
+        default: 'codecept'
+        type: string
+      lint-docs:
+        description: 'Run docs lint after tests.'
+        default: true
+        type: boolean
+      runs-on:
+        description: 'Runner image. Defaults to ubuntu-22.04 to match the previous Travis "jammy" dist.'
+        default: 'ubuntu-22.04'
+        type: string
+    secrets:
+      DOCKER_USERNAME:
+        required: true
+      DOCKER_PASSWORD:
+        required: true
+
+jobs:
+  detect-tests:
+    runs-on: ${{ inputs.runs-on }}
+    outputs:
+      has-tests: ${{ steps.check.outputs.has-tests }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - id: check
+        shell: bash
+        run: |
+          if [ -n "$(find tests -maxdepth 1 -name '*.suite.yml' 2>/dev/null)" ]; then
+            echo "has-tests=true" >> "$GITHUB_OUTPUT"
+            echo "Found Codeception suite files; will run tests."
+          else
+            echo "has-tests=false" >> "$GITHUB_OUTPUT"
+            echo "No Codeception suite files in tests/; skipping test job."
+          fi
+
+  test:
+    needs: detect-tests
+    if: needs.detect-tests.outputs.has-tests == 'true'
+    runs-on: ${{ inputs.runs-on }}
+    env:
+      COMPOSE_HTTP_TIMEOUT: '360'
+      ES_MEM_LIMIT: '2g'
+      COMPOSER_NO_INTERACTION: '1'
+      ALTIS_PACKAGE: ${{ inputs.altis-package }}
+      BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ inputs.php-version }}
+          tools: composer:v2
+          coverage: none
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ inputs.node-version }}
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.composer/cache
+          key: composer-${{ runner.os }}-php${{ inputs.php-version }}-${{ hashFiles('composer.json', 'composer.lock') }}
+          restore-keys: |
+            composer-${{ runner.os }}-php${{ inputs.php-version }}-
+
+      - name: Authenticate with Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Compute base branch
+        id: base
+        shell: bash
+        run: |
+          if [[ "$BRANCH_NAME" =~ ^(v[0-9]{2}-branch)$ ]]; then
+            BASE_BRANCH="${BASH_REMATCH[1]}"
+          else
+            BASE_BRANCH="dev-master"
+          fi
+          echo "base-branch=$BASE_BRANCH" >> "$GITHUB_OUTPUT"
+          echo "Branch under test: $BRANCH_NAME"
+          echo "Base branch:       $BASE_BRANCH"
+
+      - name: Create Altis test root
+        env:
+          BASE_BRANCH: ${{ steps.base.outputs.base-branch }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          composer create-project "altis/skeleton:dev-${BRANCH_NAME}" \
+            --stability=dev --ignore-platform-req=php+ --ignore-platform-req=ext-* \
+            "$HOME/test-root" || \
+          composer create-project "altis/skeleton:dev-${BASE_BRANCH}" \
+            --stability=dev --ignore-platform-req=php+ --ignore-platform-req=ext-* \
+            "$HOME/test-root"
+
+      - name: Install test theme and inject package under test
+        env:
+          BASE_BRANCH: ${{ steps.base.outputs.base-branch }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd "$HOME/test-root"
+
+          # Install Altis test theme.
+          composer require altis/test-theme --ignore-platform-req=php+ --ignore-platform-req=ext-*
+
+          # Mark the test theme as the default.
+          jq '. * {"extra":{"altis":{"modules":{"cms":{"default-theme":"test-theme"}}}}}' composer.json > composer.json.tmp
+          mv composer.json.tmp composer.json
+
+          # Inject the package under test, aliased so composer accepts the dev branch
+          # against any existing version constraint. Mirrors travis/module.yml.
+          INSTALLED_VERSION=$(jq -r ".packages[] | select (.name==\"$ALTIS_PACKAGE\") | .version" composer.lock)
+          ALIAS_VERSION=$(printf '%s' "$INSTALLED_VERSION" | sed -e '/^dev/q;s/$/9/')
+          composer require -W "$ALTIS_PACKAGE:dev-${BRANCH_NAME} as ${ALIAS_VERSION}"
+
+      - name: Generate WP salts and load.php guard
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd "$HOME/test-root"
+          echo "<?php" > .config/salts.php
+          curl -fsSL "https://api.wordpress.org/secret-key/1.1/salt/" >> .config/salts.php
+          if [ ! -f .config/load.php ]; then
+            echo "<?php" > .config/load.php
+          fi
+          cat >> .config/load.php <<'PHP'
+          if ( ( Altis\get_environment_type() === 'local' ) || ( Altis\get_environment_type() === 'ci' ) ) {
+              if ( ! defined( 'AUTH_KEY' ) ) {
+                  require_once __DIR__ . '/salts.php';
+              }
+          }
+          PHP
+
+      - name: Start local server
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd "$HOME/test-root"
+          composer server start
+
+      - name: Run Codeception tests
+        if: inputs.test-command == 'codecept'
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd "$HOME/test-root"
+          composer dev-tools codecept run -p "vendor/${ALTIS_PACKAGE}/tests"
+
+      - name: Run PHPUnit tests
+        if: inputs.test-command == 'phpunit'
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd "$HOME/test-root"
+          composer dev-tools phpunit "vendor/${ALTIS_PACKAGE}"
+
+      - name: Bootstrap docs lint
+        if: inputs.lint-docs
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd "$HOME/test-root"
+          composer dev-tools bootstrap lintdocs
+
+      - name: Lint docs
+        if: inputs.lint-docs
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd "$HOME/test-root"
+          composer dev-tools lintdocs -l "vendor/${ALTIS_PACKAGE}" all
+
+      - name: Upload Codeception output on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: codecept-output-${{ inputs.altis-package }}-php${{ inputs.php-version }}
+          path: |
+            ~/test-root/.tests/_output/
+            ~/test-root/tests/_output/
+            ~/test-root/vendor/${{ inputs.altis-package }}/tests/_output/
+          if-no-files-found: ignore
+          retention-days: 7

--- a/.github/workflows/module-ci.yml
+++ b/.github/workflows/module-ci.yml
@@ -38,27 +38,7 @@ on:
         required: true
 
 jobs:
-  detect-tests:
-    runs-on: ${{ inputs.runs-on }}
-    outputs:
-      has-tests: ${{ steps.check.outputs.has-tests }}
-    steps:
-      - uses: actions/checkout@v4
-
-      - id: check
-        shell: bash
-        run: |
-          if [ -n "$(find tests -maxdepth 1 -name '*.suite.yml' 2>/dev/null)" ]; then
-            echo "has-tests=true" >> "$GITHUB_OUTPUT"
-            echo "Found Codeception suite files; will run tests."
-          else
-            echo "has-tests=false" >> "$GITHUB_OUTPUT"
-            echo "No Codeception suite files in tests/; skipping test job."
-          fi
-
   test:
-    needs: detect-tests
-    if: needs.detect-tests.outputs.has-tests == 'true'
     runs-on: ${{ inputs.runs-on }}
     env:
       COMPOSE_HTTP_TIMEOUT: '360'

--- a/docs/continuous-integration.md
+++ b/docs/continuous-integration.md
@@ -3,34 +3,45 @@
 It is common practice to use some form of Continuous Integration service on projects. There are many benefits to this such as
 running tests and code linting tools.
 
-[Travis CI](https://travis-ci.com) is the recommended tool for testing with Altis.
+[GitHub Actions](https://docs.github.com/actions) is the recommended tool for testing Altis modules. Altis provides a reusable
+workflow at `humanmade/altis-dev-tools/.github/workflows/altis-ci.yml` that handles `composer install`, `composer local-server
+start`, and runs your tests.
 
-A basic Travis configuration is installed automatically that imports the base Altis configuration and your own custom config file
-from `.config/travis.yml`.
-
-Configuration in `.config/travis.yml` will be merged into the Altis base config using a recursive-merge-append approach.
-
-The base configuration will run the following set up steps:
-
-- `composer install`
-- `composer server start`
-
-From there the tests you run are up to you. A minimal example of your `.config/travis.yml` file might look like the following:
+A minimal `.github/workflows/ci.yml` for an Altis project looks like this:
 
 ```yml
-script:
-    - composer dev-tools phpunit
-    # and/or
-    - composer dev-tools codecept run
+name: CI
+
+on:
+  push:
+    branches: [master, main, 'v*-branch']
+  pull_request:
+    branches: [master, main, 'v*-branch']
+
+jobs:
+  ci:
+    uses: humanmade/altis-dev-tools/.github/workflows/altis-ci.yml@<sha>
+    with:
+      test-command: phpunit       # or 'codecept'
+    secrets:
+      DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+      DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
 ```
+
+Pin `<sha>` to a commit on `humanmade/altis-dev-tools`. The workflow runs the following set up steps for you:
+
+- `composer install`
+- `composer local-server start`
+
+From there the tests are up to you. The most common command is `composer dev-tools phpunit` or `composer dev-tools codecept run`.
 
 See [testing with PHPUnit](./testing-with-phpunit.md) and [testing with Codeception](./testing-with-codeception.md) for more
 information on the above commands.
 
 We recommend reading and bookmarking the following:
 
-- [Travis CI documentation](https://docs.travis-ci.com/)
-- [Travis config file reference](https://config.travis-ci.com/)
+- [GitHub Actions documentation](https://docs.github.com/actions)
+- [Reusing workflows](https://docs.github.com/actions/using-workflows/reusing-workflows)
 
 Because there is a full instance of Altis running in the CI environment this enables the use of end to end testing using tools like
 the following:
@@ -39,6 +50,14 @@ the following:
 - [Cypress](https://cypress.io)
 - [Lighthouse](https://developers.google.com/web/tools/lighthouse)
 - [aXe accessibility testing](https://www.deque.com/axe/)
+
+## Using Travis CI
+
+Travis CI was the previous default and remains a fully supported option for Altis projects. The skeleton no longer ships a Travis
+template by default, but you can continue to use Travis on your own project by maintaining a `.travis.yml` file at the repository
+root. The previous module template lived at `humanmade/altis-dev-tools:travis/altis.yml` and ran the same `composer install` /
+`composer local-server start` setup; it is no longer maintained but the equivalent commands are documented above and the `ci`
+environment overrides below apply equally to both Travis and GitHub Actions runs.
 
 ## Overriding Config for CI
 
@@ -162,47 +181,63 @@ To disable Tachyon, set the following configuration:
 
 ## Conditional Builds
 
-By default builds on Travis will run any time code is pushed to the repository or merged regardless of branch. You can use
-Travis' [conditional builds feature](https://docs.travis-ci.com/user/conditions-v1) to determine when a build should run. The
-following configuration examples show how to achieve some common set ups:
+By default builds will run any time code is pushed to the repository or a pull request is opened. To restrict when a workflow
+runs, use the standard GitHub Actions [`on` triggers](https://docs.github.com/actions/using-workflows/events-that-trigger-workflows)
+and [path/branch filters](https://docs.github.com/actions/using-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet).
+A few common setups:
+
+```yaml
+# Only run on pull requests
+on:
+  pull_request:
+
+# Only run on specific branches (push and PRs targeting them)
+on:
+  push:
+    branches: [staging, development]
+  pull_request:
+    branches: [staging, development]
+
+# Skip the workflow on commits that only touch documentation
+on:
+  push:
+    paths-ignore:
+      - 'docs/**'
+      - '*.md'
+```
+
+If you are still on Travis CI, the equivalent feature is [conditional builds](https://docs.travis-ci.com/user/conditions-v1):
 
 ```yaml
 # Only run on pull requests
 if: type = pull_request
 
-# Only run on specific branches (and pull requests to those branches)
+# Only run on specific branches
 if: branch IN (staging, development)
-
-# Combining the above
-if: type = pull_request AND branch IN (staging, development)
 ```
-
-There are many built in values and types of operator you can make use of in your config, as well
-as [setting conditions per stage for multistage builds](https://docs.travis-ci.com/user/build-stages/).
-
-## Migrating From An Existing Travis Config
-
-If you already have an existing Travis configuration then follow these steps:
-
-1. Copy `.travis.yml` to `.config/travis.yml`
-1. Compare this file to the one in `vendor/altis/dev-tools/travis/altis.yml`:
-
-- Remove any duplicate items from `.config/travis.yml`
-- Remove additional PHP versions if you have a PHP version matrix
-- Update any `phpunit` commands to use `composer dev-tools phpunit`. If you pass any arguments to `phpunit` you must separate them
-  with the options delimiter `--` e.g. `composer dev-tools phpunit -- [options]`
-
-1. Commit these changes to a branch and create a pull request
-1. Confirm that the build works and tests pass
-
-Please contact support if you require any assistance with migrating.
 
 ## Overriding The Base Config
 
-If you need to fully override the base config you can remove the line importing `humanmade/altis-dev-tools:travis/altis.yml` and
-committing the change. You can then add your full configuration to `.config/travis.yml`.
+For most projects the reusable workflow is enough. If you need to override or extend it — extra steps, custom matrix, services,
+artifacts — copy the steps from `humanmade/altis-dev-tools/.github/workflows/altis-ci.yml` directly into your own
+`.github/workflows/ci.yml` and modify them as needed. The reusable workflow's source is the canonical reference.
 
-**Note:** Altis will emit a warning on `composer install` or `composer update` if the `.travis.yml` doesn't match what's expected
-but no error codes are returned and you can safely ignore this.
+If you need different behaviour, the recommended pattern is to call the reusable workflow for the standard test job and add
+your own jobs alongside it:
 
-When overriding the base Travis config we cannot guarantee functionality within Travis or support any issues you may encounter.
+```yaml
+jobs:
+  ci:
+    uses: humanmade/altis-dev-tools/.github/workflows/altis-ci.yml@<sha>
+    secrets:
+      DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+      DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+
+  e2e:
+    needs: ci
+    runs-on: ubuntu-22.04
+    steps:
+      # your own end-to-end / Cypress / Lighthouse steps
+```
+
+When you override the base config we cannot guarantee functionality or support any issues you may encounter.

--- a/docs/testing-with-codeception.md
+++ b/docs/testing-with-codeception.md
@@ -116,10 +116,9 @@ When you invoke the `codecept run` command, this happens in the background:
 ### Continuous Integration
 
 In order to run Codeception tests in Continuous Integration environments, follow
-the [documentation on setting up Continuous Integration on Travis](https://docs.altis-dxp.com/dev-tools/continuous-integration/),
-and
-specify your test running command(s) as per the documentation above, typically using `composer dev-tools codecept run` instead of /
-in addition to `composer dev-tools phpunit` as explained in the docs.
+the [documentation on setting up Continuous Integration](https://docs.altis-dxp.com/dev-tools/continuous-integration/) and
+specify your test running command(s) as per that documentation — typically using `composer dev-tools codecept run` instead of (or
+in addition to) `composer dev-tools phpunit`.
 
 ## Writing tests
 

--- a/templates/project-ci.yml
+++ b/templates/project-ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+# Default Altis project CI workflow.
+# Installed automatically by altis/dev-tools-command. The reference after `@`
+# is re-pinned to the installed altis/dev-tools version on every
+# `composer install` / `composer update`. Customise this file freely — once it
+# diverges from the canonical template the auto-pinning stops, leaving you in
+# full control.
+
+on:
+  push:
+    branches: [master, main]
+  pull_request:
+    branches: [master, main]
+
+jobs:
+  ci:
+    uses: humanmade/altis-dev-tools/.github/workflows/altis-ci.yml@__ref_replace_me__
+    secrets:
+      DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+      DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}


### PR DESCRIPTION
## Summary

Replaces the Travis import templates (`travis/module.yml`, `travis/altis.yml`) with reusable GitHub Actions workflows that module repos call from their own `.github/workflows/ci.yml`.

- `module-ci.yml` — skeleton install, package-under-test injection, codecept/phpunit, lintdocs. Mirrors `travis/module.yml` step-for-step.
- `altis-ci.yml` — simpler workflow for the skeleton/`altis-empty` package.
- `.github/workflows/README.md` — documents inputs, required secrets, and the SHA-pinning convention.

The thin caller `.github/workflows/ci.yml` lets this repo self-test the workflow.

## Companion PRs

This must merge **first** so the per-module PRs can resolve `humanmade/altis-dev-tools/.github/workflows/module-ci.yml@master`. Once landed, run `scripts/update-module-gha-ref.sh <sha>` from `humanmade/product-dev` to pin all callers to a SHA.

The Travis files (`travis/module.yml`, `travis/altis.yml`, `.travis.yml`) stay in place for the side-by-side migration period and will be removed in a follow-up.

- Addresses: https://github.com/humanmade/product-dev/issues/1539

## Test plan

- [ ] `ci.yml` self-test runs green against `module-ci.yml@master` post-merge
- [ ] `DOCKER_USERNAME` / `DOCKER_PASSWORD` repo secrets are set
- [ ] Codeception output uploads as artifact on a forced failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)