### PR TITLE
Fix base-branch and composer-alias resolution

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -73,7 +73,7 @@ These are the same secrets the previous Travis builds used. Verify with `gh secr
 
 The `module-ci.yml` test job:
 
-1. Determine the base branch — match `vNN-branch` against the trigger ref, otherwise fall back to `dev-master`.
+1. Determine the base branch — match `vNN-branch` against the PR target ref (or the pushed branch on push events), otherwise fall back to `master`.
 2. `composer create-project altis/skeleton:dev-<branch>` into `$HOME/test-root` (with the base branch as a fallback).
 3. `composer require altis/test-theme` and set it as the default theme.
 4. `composer require <altis-package>:dev-<branch> as <aliased-version>` to inject the package being tested over any version constraint.
@@ -86,3 +86,24 @@ The `module-ci.yml` test job:
 ## Skipping when there are no tests
 
 The `detect-tests` job checks for `tests/*.suite.yml` files. If none exist, the `test` job is skipped — same early-exit behaviour as the Travis `before_install` check.
+
+## Developer-side test scripts
+
+Two shell scripts under [`tests/`](tests/) exercise the inline shell snippets in `module-ci.yml` so the logic can be checked locally without round-tripping through GitHub Actions. They are not invoked by CI; they exist for review and pre-commit verification when changing the workflow.
+
+- `ci-branch-resolution.sh` — mirrors the "Compute base branch" step. Runs a matrix of `push` and `pull_request` scenarios across `master`, `v##-branch`, and arbitrary feature branches.
+- `ci-version-resolution.sh` — mirrors the `composer require … as <alias>` derivation. Builds synthetic `composer.lock` fixtures and checks the resolved alias, including packages found under `.packages-dev` and `dev-*` installed versions.
+
+Both scripts support two modes:
+
+```bash
+# Run the full test matrix.
+.github/workflows/tests/ci-branch-resolution.sh
+.github/workflows/tests/ci-version-resolution.sh
+
+# Evaluate one ad-hoc input.
+HEAD_REF=feat/foo BASE_REF=v25-branch .github/workflows/tests/ci-branch-resolution.sh --eval
+LOCK_FILE=./composer.lock PKG=altis/cms  .github/workflows/tests/ci-version-resolution.sh --eval
+```
+
+Each script duplicates the shell logic from `module-ci.yml`. A shared source file would not work because the reusable workflow's `actions/checkout@v4` checks out the caller's repo, not this one. The YAML steps carry comments pointing at these scripts to flag drift on review.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,10 @@
 name: CI
 
-# Caller for the reusable Module CI workflow.
-# After the reusable workflow lands on master, bump `@master` to a pinned SHA via
-# scripts/update-module-gha-ref.sh.
+# Self-CI caller for dev-tools' own module-ci.yml.
+# Uses the relative-path form so this repo always tests the reusable workflow
+# at the same commit as the caller (i.e. the PR or push under test) rather
+# than whatever happens to be on master. Module repos that consume the
+# reusable workflow continue to pin via `@<sha>` in their own ci.yml.
 
 on:
   push:
@@ -18,7 +20,7 @@ on:
 
 jobs:
   ci:
-    uses: humanmade/altis-dev-tools/.github/workflows/module-ci.yml@master
+    uses: ./.github/workflows/module-ci.yml
     with:
       altis-package: altis/dev-tools
       test-command: phpunit

--- a/.github/workflows/module-ci.yml
+++ b/.github/workflows/module-ci.yml
@@ -127,9 +127,15 @@ jobs:
           # Search both packages and packages-dev (e.g. altis/local-server is require-dev in skeleton).
           # Logic mirrored in tests/ci-version-resolution.sh — keep the two in sync.
           INSTALLED_VERSION=$(jq -r '(.packages[], .["packages-dev"][]) | select(.name==$pkg) | .version' --arg pkg "$ALTIS_PACKAGE" composer.lock | head -1)
-          if [[ -z "$INSTALLED_VERSION" || "$INSTALLED_VERSION" =~ ^dev- ]]; then
+          if [[ -z "$INSTALLED_VERSION" ]]; then
+            # Package not present in lock — pick a high alias that satisfies any reasonable constraint.
             ALIAS_VERSION="9999.9.9"
+          elif [[ "$INSTALLED_VERSION" =~ ^dev- ]]; then
+            # Sibling packages may carry a `dev-master` (or similar) constraint on this package; alias to
+            # the installed dev branch so the constraint is still satisfied. Mirrors Travis's `/^dev/q` sed.
+            ALIAS_VERSION="$INSTALLED_VERSION"
           else
+            # Concrete X.Y.Z — bump patch so the dev branch satisfies any caret/tilde constraint at that level.
             ALIAS_VERSION="${INSTALLED_VERSION}9"
           fi
           composer require -W "$ALTIS_PACKAGE:dev-${BRANCH_NAME} as ${ALIAS_VERSION}"

--- a/.github/workflows/module-ci.yml
+++ b/.github/workflows/module-ci.yml
@@ -45,7 +45,11 @@ jobs:
       ES_MEM_LIMIT: '2g'
       COMPOSER_NO_INTERACTION: '1'
       ALTIS_PACKAGE: ${{ inputs.altis-package }}
+      # BRANCH_NAME = source branch on PRs, pushed branch on push events.
+      # BASE_REF    = target branch on PRs, pushed branch on push events.
+      # Mirrors travis/module.yml, where BASE_BRANCH was derived from $TRAVIS_BRANCH (the target on PRs).
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+      BASE_REF: ${{ github.base_ref || github.ref_name }}
     steps:
       - uses: actions/checkout@v4
 
@@ -76,16 +80,18 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Compute base branch
+        # Logic mirrored in tests/ci-branch-resolution.sh — keep the two in sync.
         id: base
         shell: bash
         run: |
-          if [[ "$BRANCH_NAME" =~ ^(v[0-9]{2}-branch)$ ]]; then
+          if [[ "$BASE_REF" =~ ^(v[0-9]{2}-branch)$ ]]; then
             BASE_BRANCH="${BASH_REMATCH[1]}"
           else
             BASE_BRANCH="master"
           fi
           echo "base-branch=$BASE_BRANCH" >> "$GITHUB_OUTPUT"
           echo "Branch under test: $BRANCH_NAME"
+          echo "Target ref:        $BASE_REF"
           echo "Base branch:       $BASE_BRANCH"
 
       - name: Create Altis test root
@@ -119,6 +125,7 @@ jobs:
           # Inject the package under test, aliased so composer accepts the dev branch
           # against any existing version constraint. Mirrors travis/module.yml.
           # Search both packages and packages-dev (e.g. altis/local-server is require-dev in skeleton).
+          # Logic mirrored in tests/ci-version-resolution.sh — keep the two in sync.
           INSTALLED_VERSION=$(jq -r '(.packages[], .["packages-dev"][]) | select(.name==$pkg) | .version' --arg pkg "$ALTIS_PACKAGE" composer.lock | head -1)
           if [[ -z "$INSTALLED_VERSION" || "$INSTALLED_VERSION" =~ ^dev- ]]; then
             ALIAS_VERSION="9999.9.9"

--- a/.github/workflows/tests/ci-branch-resolution.sh
+++ b/.github/workflows/tests/ci-branch-resolution.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+#
+# Test harness for the "Compute base branch" step in module-ci.yml.
+#
+# The actual logic in the workflow runs on a GitHub-hosted runner, but the
+# branch-resolution rules are simple enough to mirror locally so we can
+# exercise them without round-tripping through CI.
+#
+# IMPORTANT: keep the resolve_branches() function below in sync with the
+# corresponding step in ../module-ci.yml — there is no shared source file
+# because actions/checkout in the reusable workflow checks out the caller
+# repo, not altis-dev-tools.
+#
+# Usage:
+#   ./ci-branch-resolution.sh            # run the full test matrix
+#   ./ci-branch-resolution.sh --eval     # read HEAD_REF/BASE_REF/REF_NAME from env
+#                                     # and print the resolved branches
+# Examples:
+#   HEAD_REF=fix/foo BASE_REF=v25-branch ./ci-branch-resolution.sh --eval
+#   REF_NAME=master ./ci-branch-resolution.sh --eval
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Logic under test — must match the "Compute base branch" step in module-ci.yml
+# ---------------------------------------------------------------------------
+resolve_branches() {
+    local head_ref="${1:-}"
+    local base_ref="${2:-}"
+    local ref_name="${3:-}"
+
+    # github.head_ref || github.ref_name
+    local branch_name="${head_ref:-$ref_name}"
+    # github.base_ref || github.ref_name
+    local target_ref="${base_ref:-$ref_name}"
+
+    local base_branch
+    if [[ "$target_ref" =~ ^(v[0-9]{2}-branch)$ ]]; then
+        base_branch="${BASH_REMATCH[1]}"
+    else
+        base_branch="master"
+    fi
+
+    printf 'branch-name=%s\nbase-branch=%s\n' "$branch_name" "$base_branch"
+}
+
+# ---------------------------------------------------------------------------
+# Ad-hoc evaluation mode
+# ---------------------------------------------------------------------------
+if [[ "${1:-}" == "--eval" ]]; then
+    resolve_branches "${HEAD_REF:-}" "${BASE_REF:-}" "${REF_NAME:-}"
+    exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Test matrix: name | HEAD_REF | BASE_REF | REF_NAME | want branch | want base
+# Empty HEAD_REF/BASE_REF mimics a push event; populated mimics a pull_request.
+# ---------------------------------------------------------------------------
+cases=(
+    "push to master                     |              |             | master      | master      | master"
+    "push to v23-branch                 |              |             | v23-branch  | v23-branch  | v23-branch"
+    "push to v26-branch                 |              |             | v26-branch  | v26-branch  | v26-branch"
+    "PR feat -> master                  | feat/foo     | master      |             | feat/foo    | master"
+    "PR feat -> v23-branch              | feat/foo     | v23-branch  |             | feat/foo    | v23-branch"
+    "PR feat -> v26-branch              | bug/123      | v26-branch  |             | bug/123     | v26-branch"
+    "PR v25-branch -> master            | v25-branch   | master      |             | v25-branch  | master"
+    "PR with slashy name -> v24-branch  | fix/some/dir | v24-branch  |             | fix/some/dir| v24-branch"
+    "non-matching target name           | feat/foo     | dev         |             | feat/foo    | master"
+)
+
+pass=0
+fail=0
+for c in "${cases[@]}"; do
+    IFS='|' read -r name head base ref want_branch want_base <<<"$c"
+    # Strip surrounding whitespace from each field.
+    name=$(echo "$name" | xargs)
+    head=$(echo "$head" | xargs)
+    base=$(echo "$base" | xargs)
+    ref=$(echo "$ref"  | xargs)
+    want_branch=$(echo "$want_branch" | xargs)
+    want_base=$(echo "$want_base" | xargs)
+
+    out=$(resolve_branches "$head" "$base" "$ref")
+    got_branch=$(printf '%s\n' "$out" | sed -n 's/^branch-name=//p')
+    got_base=$(printf '%s\n' "$out" | sed -n 's/^base-branch=//p')
+
+    if [[ "$got_branch" == "$want_branch" && "$got_base" == "$want_base" ]]; then
+        printf '  PASS  %s\n' "$name"
+        pass=$((pass + 1))
+    else
+        printf '  FAIL  %s\n' "$name"
+        printf '          inputs:  head=%q base=%q ref=%q\n' "$head" "$base" "$ref"
+        printf '          wanted:  branch=%q  base=%q\n' "$want_branch" "$want_base"
+        printf '          got:     branch=%q  base=%q\n' "$got_branch" "$got_base"
+        fail=$((fail + 1))
+    fi
+done
+
+printf '\n%d passed, %d failed\n' "$pass" "$fail"
+[[ $fail -eq 0 ]]

--- a/.github/workflows/tests/ci-version-resolution.sh
+++ b/.github/workflows/tests/ci-version-resolution.sh
@@ -1,0 +1,197 @@
+#!/usr/bin/env bash
+#
+# Test harness for the composer alias-version logic in module-ci.yml's
+# "Install test theme and inject package under test" step.
+#
+# The workflow does:
+#   composer require -W "$ALTIS_PACKAGE:dev-${BRANCH_NAME} as ${ALIAS_VERSION}"
+# where ALIAS_VERSION is derived from composer.lock so the dev branch satisfies
+# whatever version constraint is already on the package.
+#
+# IMPORTANT: keep the resolve_alias_version() function below in sync with the
+# corresponding step in ../module-ci.yml — there is no shared source file
+# because actions/checkout in the reusable workflow checks out the caller
+# repo, not altis-dev-tools.
+#
+# Usage:
+#   ./ci-version-resolution.sh         # run the full test matrix
+#   ./ci-version-resolution.sh --eval  # read LOCK_FILE and PKG from env, print result
+# Examples:
+#   LOCK_FILE=./composer.lock PKG=altis/cms ./ci-version-resolution.sh --eval
+
+set -euo pipefail
+
+if ! command -v jq >/dev/null 2>&1; then
+    echo "jq is required" >&2
+    exit 2
+fi
+
+# ---------------------------------------------------------------------------
+# Logic under test — must match the step in module-ci.yml
+# ---------------------------------------------------------------------------
+resolve_alias_version() {
+    local lock_file="$1"
+    local pkg="$2"
+
+    local installed_version
+    installed_version=$(
+        jq -r '(.packages[], .["packages-dev"][]) | select(.name==$pkg) | .version' \
+            --arg pkg "$pkg" "$lock_file" \
+        | head -1
+    )
+
+    local alias_version
+    if [[ -z "$installed_version" || "$installed_version" =~ ^dev- ]]; then
+        alias_version="9999.9.9"
+    else
+        alias_version="${installed_version}9"
+    fi
+
+    printf 'installed-version=%s\nalias-version=%s\n' "$installed_version" "$alias_version"
+}
+
+# ---------------------------------------------------------------------------
+# Ad-hoc evaluation mode
+# ---------------------------------------------------------------------------
+if [[ "${1:-}" == "--eval" ]]; then
+    if [[ -z "${LOCK_FILE:-}" || -z "${PKG:-}" ]]; then
+        echo "Usage: LOCK_FILE=path/to/composer.lock PKG=altis/cms $0 --eval" >&2
+        exit 2
+    fi
+    resolve_alias_version "$LOCK_FILE" "$PKG"
+    exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Test matrix
+# ---------------------------------------------------------------------------
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT
+
+write_lock() {
+    # Reads JSON from stdin, writes to a fresh temp file, echoes the path.
+    local path
+    path=$(mktemp "$tmp_dir/lock.XXXXXX.json")
+    cat >"$path"
+    echo "$path"
+}
+
+pass=0
+fail=0
+run_case() {
+    local name="$1" lock="$2" pkg="$3" want_alias="$4"
+    local got_alias
+    got_alias=$(resolve_alias_version "$lock" "$pkg" | sed -n 's/^alias-version=//p')
+    if [[ "$got_alias" == "$want_alias" ]]; then
+        printf '  PASS  %s\n' "$name"
+        pass=$((pass + 1))
+    else
+        printf '  FAIL  %s\n' "$name"
+        printf '          want alias: %s\n          got  alias: %s\n' "$want_alias" "$got_alias"
+        fail=$((fail + 1))
+    fi
+}
+
+# Case 1: concrete X.Y.Z version in .packages -> X.Y.Z9
+LOCK=$(write_lock <<'JSON'
+{
+  "packages":     [ {"name":"altis/cms","version":"1.2.3"} ],
+  "packages-dev": []
+}
+JSON
+)
+run_case "concrete version in packages"           "$LOCK" "altis/cms"           "1.2.39"
+
+# Case 2: concrete X.Y.Z version in .packages-dev -> X.Y.Z9
+# This is the bug fix (altis/local-server lives in skeleton's require-dev).
+LOCK=$(write_lock <<'JSON'
+{
+  "packages":     [ {"name":"altis/cms","version":"1.2.3"} ],
+  "packages-dev": [ {"name":"altis/local-server","version":"4.5.6"} ]
+}
+JSON
+)
+run_case "concrete version in packages-dev"       "$LOCK" "altis/local-server" "4.5.69"
+
+# Case 3: dev-* installed version -> 9999.9.9
+LOCK=$(write_lock <<'JSON'
+{
+  "packages":     [ {"name":"altis/cms","version":"dev-master"} ],
+  "packages-dev": []
+}
+JSON
+)
+run_case "dev-master installed"                   "$LOCK" "altis/cms"          "9999.9.9"
+
+LOCK=$(write_lock <<'JSON'
+{
+  "packages":     [ {"name":"altis/cms","version":"dev-feature-branch"} ],
+  "packages-dev": []
+}
+JSON
+)
+run_case "dev-feature-branch installed"           "$LOCK" "altis/cms"          "9999.9.9"
+
+# Case 4: package not present in either array -> 9999.9.9
+LOCK=$(write_lock <<'JSON'
+{
+  "packages":     [ {"name":"altis/cms","version":"1.2.3"} ],
+  "packages-dev": []
+}
+JSON
+)
+run_case "package missing entirely"               "$LOCK" "altis/seo"          "9999.9.9"
+
+# Case 5: empty lock arrays -> 9999.9.9
+LOCK=$(write_lock <<'JSON'
+{ "packages": [], "packages-dev": [] }
+JSON
+)
+run_case "empty lock"                             "$LOCK" "altis/cms"          "9999.9.9"
+
+# Case 6: package in BOTH arrays -> head -1 picks the first hit (.packages first)
+LOCK=$(write_lock <<'JSON'
+{
+  "packages":     [ {"name":"altis/cms","version":"1.0.0"} ],
+  "packages-dev": [ {"name":"altis/cms","version":"2.0.0"} ]
+}
+JSON
+)
+run_case "duplicate name, packages wins"          "$LOCK" "altis/cms"          "1.0.09"
+
+# Case 7: prerelease suffix is preserved, with `9` appended
+LOCK=$(write_lock <<'JSON'
+{
+  "packages":     [ {"name":"altis/cms","version":"1.2.3-RC1"} ],
+  "packages-dev": []
+}
+JSON
+)
+run_case "prerelease suffix preserved"            "$LOCK" "altis/cms"          "1.2.3-RC19"
+
+# Case 8: only matching package among many entries -> picks correct one
+LOCK=$(write_lock <<'JSON'
+{
+  "packages": [
+    {"name":"johnpbloch/wordpress","version":"6.4.0"},
+    {"name":"altis/cms","version":"7.8.9"},
+    {"name":"altis/seo","version":"3.0.0"}
+  ],
+  "packages-dev": []
+}
+JSON
+)
+run_case "selects correct package among many"     "$LOCK" "altis/cms"          "7.8.99"
+
+# Case 9: package only in packages-dev, package-with-same-prefix in packages -> exact match wins
+LOCK=$(write_lock <<'JSON'
+{
+  "packages":     [ {"name":"altis/cms","version":"1.0.0"} ],
+  "packages-dev": [ {"name":"altis/cms-dev-tools","version":"2.0.0"} ]
+}
+JSON
+)
+run_case "exact name match (no substring)"        "$LOCK" "altis/cms-dev-tools" "2.0.09"
+
+printf '\n%d passed, %d failed\n' "$pass" "$fail"
+[[ $fail -eq 0 ]]

--- a/.github/workflows/tests/ci-version-resolution.sh
+++ b/.github/workflows/tests/ci-version-resolution.sh
@@ -41,8 +41,10 @@ resolve_alias_version() {
     )
 
     local alias_version
-    if [[ -z "$installed_version" || "$installed_version" =~ ^dev- ]]; then
+    if [[ -z "$installed_version" ]]; then
         alias_version="9999.9.9"
+    elif [[ "$installed_version" =~ ^dev- ]]; then
+        alias_version="$installed_version"
     else
         alias_version="${installed_version}9"
     fi
@@ -121,7 +123,7 @@ LOCK=$(write_lock <<'JSON'
 }
 JSON
 )
-run_case "dev-master installed"                   "$LOCK" "altis/cms"          "9999.9.9"
+run_case "dev-master installed"                   "$LOCK" "altis/cms"          "dev-master"
 
 LOCK=$(write_lock <<'JSON'
 {
@@ -130,7 +132,7 @@ LOCK=$(write_lock <<'JSON'
 }
 JSON
 )
-run_case "dev-feature-branch installed"           "$LOCK" "altis/cms"          "9999.9.9"
+run_case "dev-feature-branch installed"           "$LOCK" "altis/cms"          "dev-feature-branch"
 
 # Case 4: package not present in either array -> 9999.9.9
 LOCK=$(write_lock <<'JSON'


### PR DESCRIPTION
Following on from #1055, there were still a couple of edge cases in the module CI workflow worth tightening up before module repos start consuming the reusable workflow at scale: the branch-resolution regex was being tested against the wrong ref on PRs (so feature PRs targeting a `v##-branch` fell back to a `master` skeleton), and the new composer alias produced `9999.9.9` for `dev-*` installed versions, which doesn't satisfy a `dev-master` constraint from sibling packages. This PR fixes both, adds developer-side test scripts that mirror the inline shell logic, and flips the dev-tools self-CI caller to a relative-path reference so workflow changes are exercised by their own PRs.

## Summary
- **Branch resolution**: test the `v##-branch` regex against the PR target ref (`github.base_ref`) instead of the source ref. Previously a feature PR against a `v##-branch` resolved `BASE_BRANCH=master` and the skeleton fallback installed master-version Altis.
- **Composer alias regression** (follow-up to #1055): for `dev-*` installed versions, alias to the installed version itself instead of `9999.9.9`. The `9999.9.9` alias only satisfies numeric constraints and breaks sibling packages that require this package as `dev-master`. Travis handled this correctly via its `/^dev/q` sed short-circuit; this restores that behaviour while keeping #1055's `packages-dev` lookup and missing-package fallback.
- **Self-CI**: switch dev-tools' own caller (`.github/workflows/ci.yml`) to the relative-path form `./.github/workflows/module-ci.yml`, so this repo always tests the workflow at the PR commit instead of master's copy. Without this, workflow changes here aren't exercised by their own PR.
- **Test scripts** under `.github/workflows/tests/` mirroring both inline shell snippets, runnable locally.
- Refresh `workflows/README.md` to document the test scripts and correct the base-branch fallback description.

## Why

### Branch resolution
Travis derived `BASE_BRANCH` from `$TRAVIS_BRANCH` (the PR target on PRs); `github.head_ref` (used by `BRANCH_NAME`) is the source on PRs, so the GHA equivalent is `github.base_ref`.

| Event | Before | After |
|---|---|---|
| push `master` | `master` | `master` |
| push `v##-branch` | `v##-branch` | `v##-branch` |
| PR `feat/*` -> `master` | `master` | `master` |
| PR `feat/*` -> `v##-branch` | `master` (BUG) | `v##-branch` |

### Composer alias
The dev-tools self-CI run on this PR initially failed with:

```
altis/cms is locked to version dev-master and an update of this package was not requested.
altis/cms dev-master requires altis/dev-tools dev-master -> found altis/dev-tools[dev-master] but it conflicts with your root composer.json require (dev-fix-base-branch-resolution as 9999.9.9).
```

PR #1055 changed the alias logic so any `dev-*` installed version produced `9999.9.9`, but Travis emitted the literal version (e.g. `dev-master`). For dev-tools — which most altis modules require as `dev-master` — the `9999.9.9` alias doesn't satisfy that constraint and resolution fails. The fix:

| `INSTALLED_VERSION` | Alias |
|---|---|
| empty / not in lock | `9999.9.9` (sensible fallback) |
| `dev-*` | `$INSTALLED_VERSION` (e.g. `dev-master`) |
| concrete `X.Y.Z` | `X.Y.Z9` |

## Test scripts
Both live under `.github/workflows/tests/` and ship as developer-side tools (not wired into CI for now). Each has a full matrix and an `--eval` mode for ad-hoc input. See `.github/workflows/README.md` for usage.

- `ci-branch-resolution.sh` — 9 cases covering pushes and PRs across `master`, `v##-branch`, slashy source names, and a non-matching target.
- `ci-version-resolution.sh` — 10 cases covering concrete versions in `.packages` / `.packages-dev`, missing packages, `dev-*` versions, prerelease suffixes, duplicates, and exact-name matching.

## Test plan
- [x] `.github/workflows/tests/ci-branch-resolution.sh` (9 passed, 0 failed)
- [x] `.github/workflows/tests/ci-version-resolution.sh` (10 passed, 0 failed)
- [x] dev-tools self-CI green on this PR ([run 25568838894](https://github.com/humanmade/altis-dev-tools/actions/runs/25568838894))
- [ ] Verify against a real PR from a module repo (e.g. `altis-local-server`) targeting a `v##-branch` once the SHA is bumped

🤖 Generated with [Claude Code](https://claude.com/claude-code)