### PR TITLE
Bump query-monitor floor to ^3.20.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
 		]
 	},
 	"require": {
-		"johnbillion/query-monitor": "^3.20.2",
+		"johnbillion/query-monitor": "^3.20.4",
 		"altis/dev-tools-command": "^0.8.2",
 		"wp-phpunit/wp-phpunit": "6.8.1",
 		"yoast/phpunit-polyfills": "^4.0.0",


### PR DESCRIPTION
## Summary
- Raises the `johnbillion/query-monitor` constraint floor from `^3.20.2` to `^3.20.4` so fresh installs pick up the latest 3.20.x patch releases by default.
- v23–v26 remain on the 3.x line (master is already on `^4.0.6`).

## Test plan
- [ ] CI passes
- [ ] `composer update johnbillion/query-monitor` resolves to 3.20.4

🤖 Generated with [Claude Code](https://claude.com/claude-code)