### PR TITLE
Restrict non-master Dependabot updates to patch-level

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,10 @@ updates:
     interval: weekly
   ignore:
     - dependency-name: "wp-phpunit/wp-phpunit"
+    - dependency-name: "*"
+      update-types:
+        - "version-update:semver-major"
+        - "version-update:semver-minor"
   open-pull-requests-limit: 10
   allow:
     - dependency-type: "direct"
@@ -31,6 +35,10 @@ updates:
     interval: weekly
   ignore:
     - dependency-name: "wp-phpunit/wp-phpunit"
+    - dependency-name: "*"
+      update-types:
+        - "version-update:semver-major"
+        - "version-update:semver-minor"
   open-pull-requests-limit: 10
   allow:
     - dependency-type: "direct"
@@ -44,6 +52,10 @@ updates:
     interval: weekly
   ignore:
     - dependency-name: "wp-phpunit/wp-phpunit"
+    - dependency-name: "*"
+      update-types:
+        - "version-update:semver-major"
+        - "version-update:semver-minor"
   open-pull-requests-limit: 10
   allow:
     - dependency-type: "direct"
@@ -57,6 +69,10 @@ updates:
     interval: weekly
   ignore:
     - dependency-name: "wp-phpunit/wp-phpunit"
+    - dependency-name: "*"
+      update-types:
+        - "version-update:semver-major"
+        - "version-update:semver-minor"
   open-pull-requests-limit: 10
   allow:
   - dependency-type: "direct"


### PR DESCRIPTION
## Summary
- Adds a wildcard `ignore` rule for `version-update:semver-major` and `version-update:semver-minor` to the v23/v24/v25/v26 Dependabot entries.
- Preserves the existing `wp-phpunit/wp-phpunit` ignore on every entry (overlapping rules combine — wp-phpunit stays fully ignored, everything else is patch-only on non-master).
- Master continues to receive everything.

## Test plan
- [ ] After merge, confirm the next weekly Dependabot run on a non-master branch only opens patch-level PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)