### PR TITLE
Bypass Packagist for the package under test in module-ci.yml

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -76,12 +76,13 @@ The `module-ci.yml` test job:
 1. Determine the base branch — match `vNN-branch` against the PR target ref (or the pushed branch on push events), otherwise fall back to `master`.
 2. `composer create-project altis/skeleton:dev-<branch>` into `$HOME/test-root` (with the base branch as a fallback).
 3. `composer require altis/test-theme` and set it as the default theme.
-4. `composer require <altis-package>:dev-<branch> as <aliased-version>` to inject the package being tested over any version constraint.
-5. Generate `.config/salts.php` from the WordPress salts API and append a load guard to `.config/load.php`.
-6. `composer server start`.
-7. `composer dev-tools codecept run -p vendor/<altis-package>/tests` (or `phpunit`).
-8. `composer dev-tools bootstrap lintdocs` + `composer dev-tools lintdocs -l vendor/<altis-package> all`.
-9. On failure, upload Codeception output as a workflow artifact (named `codecept-output-<package>-php<version>`).
+4. Register `humanmade/altis-<name>.git` as a `vcs` repository for the package under test, bypassing Packagist (whose CDN can lag behind a freshly pushed branch).
+5. `composer require <altis-package>:dev-<branch> as <aliased-version>` to inject the package being tested over any version constraint.
+6. Generate `.config/salts.php` from the WordPress salts API and append a load guard to `.config/load.php`.
+7. `composer server start`.
+8. `composer dev-tools codecept run -p vendor/<altis-package>/tests` (or `phpunit`).
+9. `composer dev-tools bootstrap lintdocs` + `composer dev-tools lintdocs -l vendor/<altis-package> all`.
+10. On failure, upload Codeception output as a workflow artifact (named `codecept-output-<package>-php<version>`).
 
 ## Skipping when there are no tests
 

--- a/.github/workflows/module-ci.yml
+++ b/.github/workflows/module-ci.yml
@@ -122,16 +122,11 @@ jobs:
           jq '. * {"extra":{"altis":{"modules":{"cms":{"default-theme":"test-theme"}}}}}' composer.json > composer.json.tmp
           mv composer.json.tmp composer.json
 
-          # Bypass Packagist for the package under test by registering its GitHub
-          # repo as a VCS source. Packagist's CDN can lag 30-90s behind a freshly
-          # pushed branch, which makes `composer require <pkg>:dev-<branch>` fail
-          # with "Could not find package …" on PRs whose CI starts immediately
-          # after the push (notably Dependabot). The git remote always sees the
-          # new branch. Convention: altis/<name> lives at humanmade/altis-<name>.
+          # Use GitHub as the source for test to avoid packagist lag causing a race condition
           composer config "repositories.$ALTIS_PACKAGE" vcs "https://github.com/humanmade/altis-${ALTIS_PACKAGE#altis/}.git"
 
           # Inject the package under test, aliased so composer accepts the dev branch
-          # against any existing version constraint. Mirrors travis/module.yml.
+          # against any existing version constraint.
           # Search both packages and packages-dev (e.g. altis/local-server is require-dev in skeleton).
           # Logic mirrored in tests/ci-version-resolution.sh — keep the two in sync.
           INSTALLED_VERSION=$(jq -r '(.packages[], .["packages-dev"][]) | select(.name==$pkg) | .version' --arg pkg "$ALTIS_PACKAGE" composer.lock | head -1)

--- a/.github/workflows/module-ci.yml
+++ b/.github/workflows/module-ci.yml
@@ -122,6 +122,14 @@ jobs:
           jq '. * {"extra":{"altis":{"modules":{"cms":{"default-theme":"test-theme"}}}}}' composer.json > composer.json.tmp
           mv composer.json.tmp composer.json
 
+          # Bypass Packagist for the package under test by registering its GitHub
+          # repo as a VCS source. Packagist's CDN can lag 30-90s behind a freshly
+          # pushed branch, which makes `composer require <pkg>:dev-<branch>` fail
+          # with "Could not find package …" on PRs whose CI starts immediately
+          # after the push (notably Dependabot). The git remote always sees the
+          # new branch. Convention: altis/<name> lives at humanmade/altis-<name>.
+          composer config "repositories.$ALTIS_PACKAGE" vcs "https://github.com/humanmade/altis-${ALTIS_PACKAGE#altis/}.git"
+
           # Inject the package under test, aliased so composer accepts the dev branch
           # against any existing version constraint. Mirrors travis/module.yml.
           # Search both packages and packages-dev (e.g. altis/local-server is require-dev in skeleton).


### PR DESCRIPTION
## Summary

- Register the module's GitHub repo as a `vcs` composer source in `module-ci.yml` before the existing inject step, so `composer require <pkg>:dev-<branch>` resolves against the git remote rather than Packagist.
- Packagist's CDN can lag 30-90s behind a freshly pushed branch, causing `Could not find package … with version dev-<branch>` failures on PRs whose CI starts immediately after the push. Pulling from GitHub directly always sees the new branch.

## Why

Concrete repro: PR #1059 (Dependabot config tweak) — workflow ran ~61s after branch push, Packagist hadn't replicated `dev-dependabot-patch-only-non-master` yet, composer require failed. A re-run minutes later succeeded with no code changes.

Travis didn't have this race because it pulled directly from a VCS repo. The new GHA workflow goes through Packagist, which is fine for normal use but flaky for "CI immediately after branch push." Most affected: Dependabot PRs, since they always trigger CI within seconds of pushing the branch.

## Scope of the change

- The `composer config repositories.<pkg> vcs <url>` runs in `\$HOME/test-root` (the throwaway skeleton clone the workflow creates each run). It mutates only that ephemeral `composer.json`.
- No module's own `composer.json` is touched, no Packagist-side config changes, nothing user-facing.
- Convention assumed: `altis/<name>` lives at `humanmade/altis-<name>.git`. True for every module today.

## Follow-up after merge

Module callers pin this workflow by SHA in their own `.github/workflows/ci.yml`. After merge, run `humanmade/altis/scripts/update-module-gha-ref.sh` to re-pin the 12 callers — same script used after #1056.

## Test plan

- [ ] CI on this PR (the `Module CI` self-test) passes.
- [ ] After merge + re-pinning, force a re-run on a Dependabot PR that previously hit the lag — should now resolve cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)