### PR TITLE
Pass test theme through to WPLoader in module CI

### DIFF
--- a/.github/workflows/module-ci.yml
+++ b/.github/workflows/module-ci.yml
@@ -118,8 +118,10 @@ jobs:
           # Install Altis test theme.
           composer require altis/test-theme --ignore-platform-req=php+ --ignore-platform-req=ext-*
 
-          # Mark the test theme as the default.
-          jq '. * {"extra":{"altis":{"modules":{"cms":{"default-theme":"test-theme"}}}}}' composer.json > composer.json.tmp
+          # Mark the test theme as the default for the CMS module, and pass it through to
+          # wp-browser's WPLoader so the test bootstrap switches to a real theme rather than
+          # tripping over the default empty `theme` string.
+          jq '. * {"extra":{"altis":{"modules":{"cms":{"default-theme":"test-theme"},"dev-tools":{"codeception":{"modules":{"config":{"WPLoader":{"theme":"test-theme"}}}}}}}}}' composer.json > composer.json.tmp
           mv composer.json.tmp composer.json
 
           # Use GitHub as the source for test to avoid packagist lag causing a race condition

--- a/.github/workflows/module-ci.yml
+++ b/.github/workflows/module-ci.yml
@@ -118,9 +118,7 @@ jobs:
           # Install Altis test theme.
           composer require altis/test-theme --ignore-platform-req=php+ --ignore-platform-req=ext-*
 
-          # Mark the test theme as the default for the CMS module, and pass it through to
-          # wp-browser's WPLoader so the test bootstrap switches to a real theme rather than
-          # tripping over the default empty `theme` string.
+          # Mark the test theme as the default for the CMS module.
           jq '. * {"extra":{"altis":{"modules":{"cms":{"default-theme":"test-theme"},"dev-tools":{"codeception":{"modules":{"config":{"WPLoader":{"theme":"test-theme"}}}}}}}}}' composer.json > composer.json.tmp
           mv composer.json.tmp composer.json
 


### PR DESCRIPTION
## Summary

Module CI runs (e.g. [altis-core run 25849311914](https://github.com/humanmade/altis-core/actions/runs/25849311914/job/75951774157)) fail during WPLoader bootstrap with:

```
In WPLoader.php line 839:
WPLoader: Failed to switch to theme . The theme directory "default" does not exist.
```

The workflow already requires \`altis/test-theme\` and sets it as the CMS module's \`default-theme\` in \`composer.json\`, but WPLoader reads its own \`theme\` value from \`extra.altis.modules.dev-tools.codeception.modules.config.WPLoader.theme\`. Without a value there, the dev-tools-command default of \`theme: ''\` reaches WPLoader, and wp-browser's \`activatePluginsSwitchThemeInSeparateProcess()\` casts the empty string to \`['']\` and tries to switch to a theme with an empty name — WordPress resolves that to a non-existent \"default\" theme directory and aborts the test bootstrap.

dev-tools' own CI runs green because the caller \`ci.yml\` sets \`test-command: phpunit\`, which skips WPLoader entirely. All modules that use the default (\`codecept\`) hit this.

This extends the \`jq\` filter that writes the CMS default-theme to also write the WPLoader override under \`extra.altis.modules.dev-tools.codeception\`, so the merged codeception config picks up a real theme to switch to.

## Test plan

- [ ] Trigger CI on a downstream module that uses \`test-command: codecept\` (e.g. open a no-op PR on altis-core after this lands) and confirm the WPLoader theme-switch error is gone.
- [ ] Confirm dev-tools' own self-CI (\`phpunit\`) still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)