### PR TITLE
Add composer-config input to module CI

### DIFF
--- a/.github/workflows/module-ci.yml
+++ b/.github/workflows/module-ci.yml
@@ -35,6 +35,10 @@ on:
         description: 'Optional JSON object merged into extra.altis.modules in the test-root composer.json. Used to enable opt-in module features for the CI run, e.g. ''{"media":{"private-media":true}}''.'
         default: ''
         type: string
+      composer-config:
+        description: 'Optional JSON object shallow-merged into the test-root composer.json at the top level. Use to inject keys like `repositories` for sibling deps not yet on Packagist, e.g. ''{"repositories":{"wpackagist":{"type":"composer","url":"https://wpackagist.org"}}}''. Pass repositories in object form (named keys), not array form, to coexist with the per-package vcs entry the workflow adds automatically.'
+        default: ''
+        type: string
     secrets:
       DOCKER_USERNAME:
         required: true
@@ -115,6 +119,7 @@ jobs:
         env:
           BASE_BRANCH: ${{ steps.base.outputs.base-branch }}
           MODULE_CONFIG: ${{ inputs.module-config }}
+          COMPOSER_CONFIG: ${{ inputs.composer-config }}
         shell: bash
         run: |
           set -euo pipefail
@@ -131,6 +136,16 @@ jobs:
           if [[ -n "$MODULE_CONFIG" ]]; then
             jq --argjson cfg "$MODULE_CONFIG" \
               '. * {"extra":{"altis":{"modules":$cfg}}}' \
+              composer.json > composer.json.tmp
+            mv composer.json.tmp composer.json
+          fi
+
+          # Shallow-merge any caller-provided composer config (top-level keys like `repositories`).
+          # Runs before the per-package vcs entry below so callers passing `repositories` in object
+          # form coexist with the auto-added `repositories.$ALTIS_PACKAGE` key.
+          if [[ -n "$COMPOSER_CONFIG" ]]; then
+            jq --argjson cfg "$COMPOSER_CONFIG" \
+              '. + $cfg' \
               composer.json > composer.json.tmp
             mv composer.json.tmp composer.json
           fi


### PR DESCRIPTION
## Summary

Adds a new optional `composer-config` input to `module-ci.yml`, a sibling of the existing `module-config` input but operating on top-level composer.json keys (e.g. `repositories`) rather than `extra.altis.modules`.

The caller passes a JSON object that is shallow-merged into the test-root composer.json before the per-package vcs entry is auto-added later in the same step.

## Motivation

altis/advanced-security depends on `wpackagist-plugin/patchstack`. The wpackagist repository is not configured by altis/skeleton — we are intentionally waiting for the plugin to be published on Packagist proper rather than wiring wpackagist into the skeleton's repositories.

Without a way for the caller to inject the wpackagist source for its own CI, composer could not resolve the dep and the package-under-test injection failed:

```
Could not find package altis/skeleton with version dev-gha-module-update.
Running composer update altis/advanced-security --with-all-dependencies
##[error]Your requirements could not be resolved to an installable set of packages.
```

After this PR lands, altis/advanced-security's `.github/workflows/ci.yml` can pass:

```yaml
with:
  altis-package: altis/advanced-security
  composer-config: '{"repositories":{"wpackagist":{"type":"composer","url":"https://wpackagist.org"}}}'
```

and the package-under-test injection step will succeed.

## Format note

Use the object form for `repositories` (`{"name": {...}}`), not the array form (`[{...}]`). The workflow auto-adds `repositories.$ALTIS_PACKAGE` as a keyed entry later in the same step — keeping the caller's input in object form avoids the array/object mismatch composer would otherwise warn about.

## Test plan

- [ ] Self-CI on this PR (uses the relative-path form in dev-tools' own ci.yml) verifies the new input doesn't break the default codepath.
- [ ] Once merged: re-pin the 12 module pin-PRs to this SHA + update altis-advanced-security's caller to pass the wpackagist injection; observe the package-under-test injection succeed.