### PR TITLE
Updated composer to WordPress wp-phpunit 7.0.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
 	"require": {
 		"johnbillion/query-monitor": "^4.0.6",
 		"altis/dev-tools-command": "^0.8.2",
-		"wp-phpunit/wp-phpunit": "6.8.1",
+		"wp-phpunit/wp-phpunit": "7.0.0",
 		"yoast/phpunit-polyfills": "^4.0.0",
 		"phpunit/phpunit": "~9.6",
 		"lucatume/wp-browser": "~4.5.15",


### PR DESCRIPTION
Update the `wp-phpunit` dependency to match WordPress 7.0

Addresses: https://github.com/humanmade/product-dev/issues/2127
