### PR TITLE
Update default CI PHP version to 8.4

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -47,7 +47,7 @@ Pin to a SHA from this repo (mirrors the `travis/module.yml@<sha>` pattern). The
 | Input | Default | Notes |
 | --- | --- | --- |
 | `altis-package` | *(required)* | Composer name (e.g. `altis/cms`). Used to install the package and locate its tests under `vendor/<altis-package>/tests`. |
-| `php-version` | `8.3` | |
+| `php-version` | `8.4` | |
 | `node-version` | `24` | |
 | `test-command` | `codecept` | Set to `phpunit` for `altis-dev-tools` itself. |
 | `lint-docs` | `true` | Run `dev-tools lintdocs` after tests. |
@@ -57,7 +57,7 @@ Pin to a SHA from this repo (mirrors the `travis/module.yml@<sha>` pattern). The
 
 | Input | Default |
 | --- | --- |
-| `php-version` | `8.3` |
+| `php-version` | `8.4` |
 | `node-version` | `24` |
 | `test-command` | `phpunit` |
 | `runs-on` | `ubuntu-22.04` |

--- a/.github/workflows/altis-ci.yml
+++ b/.github/workflows/altis-ci.yml
@@ -8,7 +8,7 @@ on:
   workflow_call:
     inputs:
       php-version:
-        default: '8.3'
+        default: '8.4'
         type: string
       node-version:
         default: '24'

--- a/.github/workflows/module-ci.yml
+++ b/.github/workflows/module-ci.yml
@@ -13,7 +13,7 @@ on:
         type: string
       php-version:
         description: 'PHP version for the runner.'
-        default: '8.3'
+        default: '8.4'
         type: string
       node-version:
         description: 'Node.js version for the runner.'


### PR DESCRIPTION
Bumps the reusable-workflow default `php-version` to 8.4.