### PR TITLE
Detect runner PHP from config.platform.php in reusable CI

### DIFF
--- a/.github/workflows/altis-ci.yml
+++ b/.github/workflows/altis-ci.yml
@@ -8,7 +8,8 @@ on:
   workflow_call:
     inputs:
       php-version:
-        default: '8.4'
+        description: 'Override the runner PHP version. Empty = detect from config.platform.php.'
+        default: ''
         type: string
       node-version:
         default: '24'
@@ -36,10 +37,22 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Detect PHP version
+        id: detect
+        env:
+          OVERRIDE: ${{ inputs.php-version }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          PHP="${OVERRIDE:-$(jq -r '.config.platform.php // "8.4"' composer.json)}"
+          PHP=$(echo "$PHP" | cut -d. -f1,2)
+          echo "php=$PHP" >> "$GITHUB_OUTPUT"
+          echo "Runner PHP: $PHP"
+
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: ${{ inputs.php-version }}
+          php-version: ${{ steps.detect.outputs.php }}
           tools: composer:v2
           coverage: none
 
@@ -52,9 +65,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.composer/cache
-          key: composer-${{ runner.os }}-php${{ inputs.php-version }}-${{ hashFiles('composer.json', 'composer.lock') }}
+          key: composer-${{ runner.os }}-${{ hashFiles('composer.json', 'composer.lock') }}
           restore-keys: |
-            composer-${{ runner.os }}-php${{ inputs.php-version }}-
+            composer-${{ runner.os }}-
 
       - name: Authenticate with Docker Hub
         uses: docker/login-action@v3
@@ -82,7 +95,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: altis-ci-output-php${{ inputs.php-version }}
+          name: altis-ci-output-php${{ steps.detect.outputs.php }}
           path: |
             tests/_output/
             .tests/_output/

--- a/.github/workflows/module-ci.yml
+++ b/.github/workflows/module-ci.yml
@@ -12,7 +12,11 @@ on:
         required: true
         type: string
       php-version:
-        description: 'PHP version for the runner.'
+        description: 'Override the runner PHP version. Empty = detect from the skeleton config.platform.php.'
+        default: ''
+        type: string
+      bootstrap-php-version:
+        description: 'PHP used to run composer before the detected version is selected.'
         default: '8.4'
         type: string
       node-version:
@@ -64,7 +68,7 @@ jobs:
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: ${{ inputs.php-version }}
+          php-version: ${{ inputs.php-version || inputs.bootstrap-php-version }}
           tools: composer:v2
           coverage: none
 
@@ -77,9 +81,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.composer/cache
-          key: composer-${{ runner.os }}-php${{ inputs.php-version }}-${{ hashFiles('composer.json', 'composer.lock') }}
+          key: composer-${{ runner.os }}-${{ hashFiles('composer.json', 'composer.lock') }}
           restore-keys: |
-            composer-${{ runner.os }}-php${{ inputs.php-version }}-
+            composer-${{ runner.os }}-
 
       - name: Authenticate with Docker Hub
         if: ${{ env.DOCKER_USERNAME != '' && env.DOCKER_PASSWORD != '' }}
@@ -118,6 +122,31 @@ jobs:
           composer create-project "altis/skeleton:dev-${BASE_BRANCH}" \
             --stability=dev --ignore-platform-req=php+ --ignore-platform-req=ext-* \
             "$HOME/test-root"
+
+      - name: Detect PHP version
+        id: detect
+        env:
+          OVERRIDE: ${{ inputs.php-version }}
+          FALLBACK: ${{ inputs.bootstrap-php-version }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ -n "$OVERRIDE" ]]; then
+            PHP="$OVERRIDE"
+          else
+            PHP=$(jq -r '.config.platform.php // empty' "$HOME/test-root/composer.json")
+            PHP="${PHP:-$FALLBACK}"
+          fi
+          PHP=$(echo "$PHP" | cut -d. -f1,2)
+          echo "php=$PHP" >> "$GITHUB_OUTPUT"
+          echo "Runner PHP: $PHP"
+
+      - name: Switch to detected PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ steps.detect.outputs.php }}
+          tools: composer:v2
+          coverage: none
 
       - name: Install test theme and inject package under test
         env:
@@ -238,7 +267,7 @@ jobs:
         shell: bash
         run: |
           # Artifact names disallow '/', so substitute the composer-name slash with '-'.
-          echo "name=codecept-output-${ALTIS_PACKAGE//\//-}-php${{ inputs.php-version }}" >> "$GITHUB_OUTPUT"
+          echo "name=codecept-output-${ALTIS_PACKAGE//\//-}-php${{ steps.detect.outputs.php }}" >> "$GITHUB_OUTPUT"
 
       - name: Upload Codeception output on failure
         if: failure()

--- a/docs/continuous-integration.md
+++ b/docs/continuous-integration.md
@@ -7,7 +7,11 @@ running tests and code linting tools.
 workflow at `humanmade/altis-dev-tools/.github/workflows/altis-ci.yml` that handles `composer install`, `composer local-server
 start`, and runs your tests.
 
-A minimal `.github/workflows/ci.yml` for an Altis project looks like this:
+`altis/dev-tools` installs and maintains this file for you: a minimal
+`.github/workflows/ci.yml` is created on `composer install`/`composer update`, and
+its `@<version>` ref is re-pinned to the installed `altis/dev-tools` version on each
+run. Once you edit the file it stops being managed and is yours to maintain. A
+managed file looks like this:
 
 ```yml
 name: CI
@@ -20,7 +24,7 @@ on:
 
 jobs:
   ci:
-    uses: humanmade/altis-dev-tools/.github/workflows/altis-ci.yml@<sha>
+    uses: humanmade/altis-dev-tools/.github/workflows/altis-ci.yml@<version>
     with:
       test-command: phpunit       # or 'codecept'
     secrets:
@@ -28,7 +32,10 @@ jobs:
       DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
 ```
 
-Pin `<sha>` to a commit on `humanmade/altis-dev-tools`. The workflow runs the following set up steps for you:
+Pin `<version>` to a released `humanmade/altis-dev-tools` tag (managed files do this
+automatically). The runner PHP version is taken from your project's
+`config.platform.php`; pass `php-version` to override it. The workflow runs the
+following set up steps for you:
 
 - `composer install`
 - `composer local-server start`
@@ -228,7 +235,7 @@ your own jobs alongside it:
 ```yaml
 jobs:
   ci:
-    uses: humanmade/altis-dev-tools/.github/workflows/altis-ci.yml@<sha>
+    uses: humanmade/altis-dev-tools/.github/workflows/altis-ci.yml@<version>
     secrets:
       DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
       DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}


### PR DESCRIPTION
## What

Reusable CI workflows (`module-ci.yml`, `altis-ci.yml`) now derive the runner PHP version from `config.platform.php` rather than a hardcoded `php-version` default.

- `altis-ci.yml`: reads `config.platform.php` from the project's own `composer.json` at checkout, then sets up PHP at that version.
- `module-ci.yml`: sets up a bootstrap PHP to run composer, creates the `altis/skeleton` test root, reads `config.platform.php` from it, then switches the runner to that version.
- `php-version` is kept as an explicit override (empty = auto-detect).
- Docs updated to reflect auto-pinning + auto-detected PHP.

## Why

Module CI took the runner PHP from the `php-version` default frozen at the pinned dev-tools SHA. This broke when `altis-skeleton` moved to PHP 8.4 on master while modules stayed on an 8.3-default pin, composer aborted. Auto-detecting from the skeleton lets one workflow serve every branch at the PHP that branch declares. Master can move ahead while vxx branches stays with their versions with no per-branch workflow edits.

## Rollout (follow-up, depends on this landing)

1. After this merges to `master` and self-CI is green, we need to create a **moving major tag** `module-ci-v1` (like actions/checkout@v4 model) on dev-tools.
2. Then a one-time migration: bump each module's `.github/workflows/ci.yml` `uses:` ref from the frozen `@<sha>` to `@module-ci-v1`, on `master` (carrying the `backport v27-branch` label for v27):
   - humanmade/altis-advanced-security#43, 
   - humanmade/altis-cloud#1193, 
   - humanmade/altis-cms#965, 
   - humanmade/altis-core#1453, 
   - humanmade/altis-documentation#729, 
   - humanmade/altis-enhanced-search#589, 
   - humanmade/altis-local-server#969, 
   - humanmade/altis-media#469, 
   - humanmade/altis-privacy#149, 
   - humanmade/altis-security#462, 
   - humanmade/altis-seo#387, 
   - humanmade/altis-sso#187
3. Repurpose `scripts/update-module-gha-ref.sh` for the tag and add v27-branch coverage; update the caller-comment guidance in module `ci.yml` files.

After the one-time migration, compatible workflow changes (incl. future PHP bumps and third-party action security fixes) roll out by moving the tag — no per-module PRs.

## Testing

- [x] Both workflows parse as valid YAML.
- [x] Detection logic verified: `8.4→8.4`, `8.3→8.3`, `8.5.0→8.5`, missing→fallback, explicit override wins.
- [x] This PR's own self-CI (relative-path `module-ci.yml`, phpunit) is the first live exercise of the detection path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
