### PR TITLE
Switch to the GH Actions as default CI

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -109,3 +109,15 @@ LOCK_FILE=./composer.lock PKG=altis/cms  .github/workflows/tests/ci-version-reso
 ```
 
 Each script duplicates the shell logic from `module-ci.yml`. A shared source file would not work because the reusable workflow's `actions/checkout@v4` checks out the caller's repo, not this one. The YAML steps carry comments pointing at these scripts to flag drift on review.
+
+## CI bootstrap guard (run by CI)
+
+Two further scripts under [`tests/`](tests/) guard the project CI bootstrap — installing this package scaffolds a project's `.github/workflows/ci.yml` from [`templates/project-ci.yml`](../../templates/project-ci.yml) via `altis/dev-tools-command`. **Unlike the mirror scripts above, these run in CI** (the `bootstrap-tests` job in [`ci.yml`](ci.yml)).
+
+- `ci-template-constraint.sh` — fast, no network: checks the `altis/dev-tools-command` constraint admits the release that consumes the template.
+- `ci-bootstrap-install.sh` — real `composer install` of a throwaway fixture, asserting `ci.yml` is scaffolded and pinned. Needs `composer` + network.
+
+```bash
+.github/workflows/tests/ci-template-constraint.sh
+.github/workflows/tests/ci-bootstrap-install.sh
+```

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,3 +27,20 @@ jobs:
     secrets:
       DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
       DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+
+  # Proves a real install of this package scaffolds .github/workflows/ci.yml
+  # from templates/project-ci.yml. See .github/workflows/tests/.
+  bootstrap-tests:
+    name: CI bootstrap tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          tools: composer
+      - name: Static template/constraint linkage check
+        run: .github/workflows/tests/ci-template-constraint.sh
+      - name: End-to-end install scaffolds ci.yml
+        run: .github/workflows/tests/ci-bootstrap-install.sh

--- a/.github/workflows/tests/ci-bootstrap-install.sh
+++ b/.github/workflows/tests/ci-bootstrap-install.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+#
+# End-to-end proof that installing this package produces the GitHub Actions CI
+# workflow. Exercises real composer resolution + the real
+# altis/dev-tools-command post-autoload-dump plugin — the only layer that sees
+# a too-low constraint, which a mocked-path unit test can't.
+#
+# Strategy (kept light — no full dev-tools dependency tree):
+#   * Resolve THIS package's real altis/dev-tools-command constraint from
+#     packagist; assert the installed version is >= 0.9.0.
+#   * Stand altis/dev-tools in via a minimal path package carrying THIS repo's
+#     real templates/project-ci.yml, giving the plugin a template to copy and a
+#     package to read the pin ref from.
+#   * composer install, then assert .github/workflows/ci.yml is created and its
+#     reusable-workflow ref is pinned (no leftover placeholder).
+#
+# Usage:
+#   ./ci-bootstrap-install.sh
+
+set -euo pipefail
+
+# First altis/dev-tools-command release that scaffolds .github/workflows/ci.yml.
+MIN_VERSION="0.9.0"
+
+if ! command -v composer >/dev/null 2>&1; then
+    echo "composer is required" >&2
+    exit 2
+fi
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+repo_root=$(cd "$script_dir/../../.." && pwd)
+template="$repo_root/templates/project-ci.yml"
+composer_json="$repo_root/composer.json"
+
+if [[ ! -f "$template" ]]; then
+    echo "templates/project-ci.yml not shipped here; nothing to test."
+    exit 0
+fi
+
+constraint=$(
+    php -r '$j = json_decode(file_get_contents($argv[1]), true); echo $j["require"]["altis/dev-tools-command"] ?? "";' \
+        "$composer_json"
+)
+if [[ -z "$constraint" ]]; then
+    echo "FAIL  composer.json does not require altis/dev-tools-command." >&2
+    exit 1
+fi
+
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT
+
+# Minimal stand-in for altis/dev-tools: forced version + the real template.
+stub_dir="$tmp_dir/dev-tools-stub"
+mkdir -p "$stub_dir/templates" "$stub_dir/travis"
+cp "$template" "$stub_dir/templates/project-ci.yml"
+# Inert Travis placeholders so a (bug-state) <=0.8.x command — which copies from
+# travis/ — completes gracefully instead of crashing on a missing file; the real
+# dev-tools still ships these. That keeps the assertions below, not a composer
+# stack trace, the thing that reports the regression.
+printf '# stub\n' >"$stub_dir/travis/tests.yml"
+printf '# stub\n' >"$stub_dir/travis/project.yml"
+cat >"$stub_dir/composer.json" <<'JSON'
+{
+    "name": "altis/dev-tools",
+    "description": "Stand-in for altis/dev-tools used by the CI bootstrap test.",
+    "version": "99.0.0",
+    "type": "wordpress-muplugin"
+}
+JSON
+
+# Fixture project that requires both packages, resolving dev-tools-command from
+# packagist via THIS repo's real constraint.
+project_dir="$tmp_dir/project"
+mkdir -p "$project_dir"
+cat >"$project_dir/composer.json" <<JSON
+{
+    "name": "altis/ci-bootstrap-test",
+    "description": "Throwaway fixture asserting the GHA CI workflow gets scaffolded.",
+    "repositories": [
+        { "type": "path", "url": "../dev-tools-stub", "options": { "symlink": false } }
+    ],
+    "require": {
+        "altis/dev-tools": "99.0.0",
+        "altis/dev-tools-command": "$constraint"
+    },
+    "config": {
+        "allow-plugins": { "altis/dev-tools-command": true }
+    }
+}
+JSON
+
+echo "Installing fixture (altis/dev-tools-command:$constraint) ..."
+( cd "$project_dir" && composer install --no-interaction --no-progress --no-ansi ) >"$tmp_dir/install.log" 2>&1 || {
+    echo "FAIL  composer install errored:" >&2
+    cat "$tmp_dir/install.log" >&2
+    exit 1
+}
+
+fail=0
+
+# --- Assertion 1: the resolved command version is GHA-aware. ----------------
+installed_version=$(
+    php -r '
+        $j = json_decode(file_get_contents($argv[1]), true);
+        $pkgs = $j["packages"] ?? $j;
+        foreach ($pkgs as $p) {
+            if (($p["name"] ?? "") === "altis/dev-tools-command") { echo $p["version"]; break; }
+        }
+    ' "$project_dir/vendor/composer/installed.json"
+)
+if [[ -z "$installed_version" ]]; then
+    echo "FAIL  altis/dev-tools-command was not installed." >&2
+    fail=1
+elif ! php -r 'exit(version_compare($argv[1], $argv[2], ">=") ? 0 : 1);' "$installed_version" "$MIN_VERSION"; then
+    echo "FAIL  Constraint '$constraint' resolved to $installed_version, below the GHA-aware $MIN_VERSION." >&2
+    echo "      This is the v27 bug class: the Travis-era command would be installed." >&2
+    fail=1
+else
+    echo "PASS  altis/dev-tools-command resolved to $installed_version (>= $MIN_VERSION)."
+fi
+
+# --- Assertion 2: the workflow file is scaffolded and pinned. ---------------
+workflow="$project_dir/.github/workflows/ci.yml"
+if [[ ! -f "$workflow" ]]; then
+    echo "FAIL  composer install did not create .github/workflows/ci.yml." >&2
+    fail=1
+else
+    if ! grep -q 'altis-ci\.yml@' "$workflow"; then
+        echo "FAIL  ci.yml does not reference the altis-ci.yml reusable workflow." >&2
+        fail=1
+    fi
+    if grep -q '__ref_replace_me__' "$workflow"; then
+        echo "FAIL  ci.yml still contains the __ref_replace_me__ placeholder; the ref was not pinned." >&2
+        fail=1
+    fi
+    [[ $fail -eq 0 ]] && echo "PASS  .github/workflows/ci.yml scaffolded and ref pinned."
+fi
+
+if [[ $fail -ne 0 ]]; then
+    echo "--- generated ci.yml (if any) ---" >&2
+    cat "$workflow" 2>/dev/null >&2 || true
+    exit 1
+fi
+
+echo
+echo "CI bootstrap install test passed."

--- a/.github/workflows/tests/ci-template-constraint.sh
+++ b/.github/workflows/tests/ci-template-constraint.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+#
+# Fails if this package ships templates/project-ci.yml but its
+# altis/dev-tools-command constraint resolves below 0.9.0 — the first release
+# that consumes the template. Below that, the template is never installed and
+# no .github/workflows/ci.yml is produced.
+#
+# Cheap, no-network half of the pair; ci-bootstrap-install.sh proves it end to
+# end.
+#
+# Usage:
+#   ./ci-template-constraint.sh
+
+set -euo pipefail
+
+# First altis/dev-tools-command release that scaffolds .github/workflows/ci.yml.
+MIN_VERSION="0.9.0"
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+repo_root=$(cd "$script_dir/../../.." && pwd)
+template="$repo_root/templates/project-ci.yml"
+composer_json="$repo_root/composer.json"
+
+# No template means an older line (<= v26) that intentionally predates the
+# GitHub Actions bootstrap. Nothing to enforce.
+if [[ ! -f "$template" ]]; then
+    echo "templates/project-ci.yml not shipped here; nothing to enforce."
+    exit 0
+fi
+
+constraint=$(
+    php -r '$j = json_decode(file_get_contents($argv[1]), true); echo $j["require"]["altis/dev-tools-command"] ?? "";' \
+        "$composer_json"
+)
+
+if [[ -z "$constraint" ]]; then
+    echo "FAIL  templates/project-ci.yml is shipped but composer.json does not require altis/dev-tools-command." >&2
+    exit 1
+fi
+
+# This guard only reasons about single-range constraints (^x, ~x, >=x, x). A
+# compound OR (e.g. '^0.8.2 || ^0.9.0') needs a human to confirm intent rather
+# than a naive floor read, so refuse instead of guessing.
+if [[ "$constraint" == *"||"* ]]; then
+    echo "FAIL  Compound constraint '$constraint' can't be checked by floor comparison." >&2
+    echo "      Update this test to reason about the OR ranges deliberately." >&2
+    exit 1
+fi
+
+# Lowest version the constraint admits = the first x.y.z token in it.
+floor=$(printf '%s' "$constraint" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+if [[ -z "$floor" ]]; then
+    echo "FAIL  Could not parse a floor version out of constraint '$constraint'." >&2
+    exit 1
+fi
+
+# floor >= MIN_VERSION?  (sort -V ascending; smaller lands first.)
+lowest=$(printf '%s\n%s\n' "$MIN_VERSION" "$floor" | sort -V | head -1)
+if [[ "$lowest" != "$MIN_VERSION" ]]; then
+    echo "FAIL  altis/dev-tools-command constraint '$constraint' (floor $floor) excludes the" >&2
+    echo "      GHA-aware $MIN_VERSION+, so templates/project-ci.yml will never be installed." >&2
+    exit 1
+fi
+
+echo "PASS  templates/project-ci.yml is shipped and altis/dev-tools-command '$constraint' admits >= $MIN_VERSION."

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
 	},
 	"require": {
 		"johnbillion/query-monitor": "^4.0.6",
-		"altis/dev-tools-command": "^0.8.2",
+		"altis/dev-tools-command": "^0.9.0",
 		"wp-phpunit/wp-phpunit": "7.0.0",
 		"yoast/phpunit-polyfills": "^4.0.0",
 		"phpunit/phpunit": "~9.6",


### PR DESCRIPTION
Require `altis/dev-tools-command ^0.9.0`.

`0.9.0` switches the project CI bootstrap from Travis to GitHub Actions: on `composer install`/`update` the command now scaffolds `.github/workflows/ci.yml` 

🤖 Generated with [Claude Code](https://claude.com/claude-code)