### PR TITLE
Add PHP-detection mirror test and run all mirror tests in CI

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -89,9 +89,9 @@ The `module-ci.yml` test job:
 
 The `detect-tests` job checks for `tests/*.suite.yml` files. If none exist, the `test` job is skipped — same early-exit behaviour as the Travis `before_install` check.
 
-## Developer-side test scripts
+## Workflow logic mirror tests
 
-Three shell scripts under [`tests/`](tests/) exercise the inline shell snippets in `module-ci.yml` (and `altis-ci.yml`) so the logic can be checked locally without round-tripping through GitHub Actions. They are not invoked by CI; they exist for review and pre-commit verification when changing the workflow.
+Three shell scripts under [`tests/`](tests/) exercise the inline shell snippets in `module-ci.yml` (and `altis-ci.yml`) so the logic can be checked without round-tripping through GitHub Actions. They run in the `bootstrap-tests` job in [`ci.yml`](ci.yml), and can also be run locally for pre-commit verification when changing the workflow.
 
 - `ci-branch-resolution.sh` — mirrors the "Compute base branch" step. Runs a matrix of `push` and `pull_request` scenarios across `master`, `v##-branch`, and arbitrary feature branches.
 - `ci-version-resolution.sh` — mirrors the `composer require … as <alias>` derivation. Builds synthetic `composer.lock` fixtures and checks the resolved alias, including packages found under `.packages-dev` and `dev-*` installed versions.
@@ -113,9 +113,9 @@ COMPOSER_JSON=./composer.json FALLBACK=8.4 .github/workflows/tests/ci-php-detect
 
 Each script duplicates the shell logic from `module-ci.yml`/`altis-ci.yml`. A shared source file would not work because the reusable workflow's `actions/checkout@v4` checks out the caller's repo, not this one. The YAML steps carry comments pointing at these scripts to flag drift on review.
 
-## CI bootstrap guard (run by CI)
+## CI bootstrap guard
 
-Two further scripts under [`tests/`](tests/) guard the project CI bootstrap — installing this package scaffolds a project's `.github/workflows/ci.yml` from [`templates/project-ci.yml`](../../templates/project-ci.yml) via `altis/dev-tools-command`. **Unlike the mirror scripts above, these run in CI** (the `bootstrap-tests` job in [`ci.yml`](ci.yml)).
+Two further scripts under [`tests/`](tests/) guard the project CI bootstrap — installing this package scaffolds a project's `.github/workflows/ci.yml` from [`templates/project-ci.yml`](../../templates/project-ci.yml) via `altis/dev-tools-command`. They run in the same `bootstrap-tests` job in [`ci.yml`](ci.yml).
 
 - `ci-template-constraint.sh` — fast, no network: checks the `altis/dev-tools-command` constraint admits the release that consumes the template.
 - `ci-bootstrap-install.sh` — real `composer install` of a throwaway fixture, asserting `ci.yml` is scaffolded and pinned. Needs `composer` + network.

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -91,24 +91,27 @@ The `detect-tests` job checks for `tests/*.suite.yml` files. If none exist, the 
 
 ## Developer-side test scripts
 
-Two shell scripts under [`tests/`](tests/) exercise the inline shell snippets in `module-ci.yml` so the logic can be checked locally without round-tripping through GitHub Actions. They are not invoked by CI; they exist for review and pre-commit verification when changing the workflow.
+Three shell scripts under [`tests/`](tests/) exercise the inline shell snippets in `module-ci.yml` (and `altis-ci.yml`) so the logic can be checked locally without round-tripping through GitHub Actions. They are not invoked by CI; they exist for review and pre-commit verification when changing the workflow.
 
 - `ci-branch-resolution.sh` — mirrors the "Compute base branch" step. Runs a matrix of `push` and `pull_request` scenarios across `master`, `v##-branch`, and arbitrary feature branches.
 - `ci-version-resolution.sh` — mirrors the `composer require … as <alias>` derivation. Builds synthetic `composer.lock` fixtures and checks the resolved alias, including packages found under `.packages-dev` and `dev-*` installed versions.
+- `ci-php-detection.sh` — mirrors the "Detect PHP version" step. Builds synthetic `composer.json` fixtures and checks the resolved runner PHP, covering `config.platform.php`, patch-level trimming to major.minor, the fallback default, and the `php-version` override.
 
-Both scripts support two modes:
+Each script supports two modes:
 
 ```bash
 # Run the full test matrix.
 .github/workflows/tests/ci-branch-resolution.sh
 .github/workflows/tests/ci-version-resolution.sh
+.github/workflows/tests/ci-php-detection.sh
 
 # Evaluate one ad-hoc input.
-HEAD_REF=feat/foo BASE_REF=v25-branch .github/workflows/tests/ci-branch-resolution.sh --eval
-LOCK_FILE=./composer.lock PKG=altis/cms  .github/workflows/tests/ci-version-resolution.sh --eval
+HEAD_REF=feat/foo BASE_REF=v25-branch  .github/workflows/tests/ci-branch-resolution.sh --eval
+LOCK_FILE=./composer.lock PKG=altis/cms .github/workflows/tests/ci-version-resolution.sh --eval
+COMPOSER_JSON=./composer.json FALLBACK=8.4 .github/workflows/tests/ci-php-detection.sh --eval
 ```
 
-Each script duplicates the shell logic from `module-ci.yml`. A shared source file would not work because the reusable workflow's `actions/checkout@v4` checks out the caller's repo, not this one. The YAML steps carry comments pointing at these scripts to flag drift on review.
+Each script duplicates the shell logic from `module-ci.yml`/`altis-ci.yml`. A shared source file would not work because the reusable workflow's `actions/checkout@v4` checks out the caller's repo, not this one. The YAML steps carry comments pointing at these scripts to flag drift on review.
 
 ## CI bootstrap guard (run by CI)
 

--- a/.github/workflows/altis-ci.yml
+++ b/.github/workflows/altis-ci.yml
@@ -38,6 +38,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Detect PHP version
+        # Logic mirrored in tests/ci-php-detection.sh — keep the two in sync.
         id: detect
         env:
           OVERRIDE: ${{ inputs.php-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Workflow logic mirror tests
+        run: |
+          .github/workflows/tests/ci-branch-resolution.sh
+          .github/workflows/tests/ci-version-resolution.sh
+          .github/workflows/tests/ci-php-detection.sh
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
         with:

--- a/.github/workflows/module-ci.yml
+++ b/.github/workflows/module-ci.yml
@@ -124,6 +124,7 @@ jobs:
             "$HOME/test-root"
 
       - name: Detect PHP version
+        # Logic mirrored in tests/ci-php-detection.sh — keep the two in sync.
         id: detect
         env:
           OVERRIDE: ${{ inputs.php-version }}

--- a/.github/workflows/tests/ci-php-detection.sh
+++ b/.github/workflows/tests/ci-php-detection.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+#
+# Test harness for the "Detect PHP version" step in module-ci.yml (and the
+# equivalent step in altis-ci.yml).
+#
+# The workflow derives the runner PHP from config.platform.php: an explicit
+# php-version input wins; otherwise it reads config.platform.php from the
+# project/skeleton composer.json, falling back to a default; then it trims the
+# result to major.minor for setup-php. module-ci.yml's fallback is the
+# bootstrap-php-version input; altis-ci.yml inlines "8.4" as the fallback.
+#
+# IMPORTANT: keep the detect_php() function below in sync with those steps —
+# there is no shared source file because actions/checkout in the reusable
+# workflow checks out the caller repo, not altis-dev-tools.
+#
+# Usage:
+#   ./ci-php-detection.sh         # run the full test matrix
+#   ./ci-php-detection.sh --eval  # read OVERRIDE/COMPOSER_JSON/FALLBACK from env, print result
+# Examples:
+#   COMPOSER_JSON=./composer.json FALLBACK=8.4 ./ci-php-detection.sh --eval
+#   OVERRIDE=8.5 ./ci-php-detection.sh --eval
+
+set -euo pipefail
+
+if ! command -v jq >/dev/null 2>&1; then
+    echo "jq is required" >&2
+    exit 2
+fi
+
+# ---------------------------------------------------------------------------
+# Logic under test — must match the "Detect PHP version" step in module-ci.yml
+# ---------------------------------------------------------------------------
+detect_php() {
+    local override="$1"
+    local composer_json="$2"
+    local fallback="$3"
+
+    local php
+    if [[ -n "$override" ]]; then
+        php="$override"
+    else
+        php=$(jq -r '.config.platform.php // empty' "$composer_json")
+        php="${php:-$fallback}"
+    fi
+    php=$(echo "$php" | cut -d. -f1,2)
+
+    printf 'php=%s\n' "$php"
+}
+
+# ---------------------------------------------------------------------------
+# Ad-hoc evaluation mode
+# ---------------------------------------------------------------------------
+if [[ "${1:-}" == "--eval" ]]; then
+    detect_php "${OVERRIDE:-}" "${COMPOSER_JSON:-/dev/null}" "${FALLBACK:-8.4}"
+    exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Test matrix
+# ---------------------------------------------------------------------------
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT
+
+write_json() {
+    # Reads JSON from stdin, writes to a fresh temp file, echoes the path.
+    local path
+    path=$(mktemp "$tmp_dir/composer.XXXXXX.json")
+    cat >"$path"
+    echo "$path"
+}
+
+pass=0
+fail=0
+run_case() {
+    local name="$1" override="$2" json="$3" fallback="$4" want="$5"
+    local got
+    got=$(detect_php "$override" "$json" "$fallback" | sed -n 's/^php=//p')
+    if [[ "$got" == "$want" ]]; then
+        printf '  PASS  %s\n' "$name"
+        pass=$((pass + 1))
+    else
+        printf '  FAIL  %s\n' "$name"
+        printf '          want php: %s\n          got  php: %s\n' "$want" "$got"
+        fail=$((fail + 1))
+    fi
+}
+
+WITH_PHP=$(write_json <<'JSON'
+{ "config": { "platform": { "php": "8.4" } } }
+JSON
+)
+run_case "platform.php 8.4"                "" "$WITH_PHP" "8.4" "8.4"
+
+OLD_PHP=$(write_json <<'JSON'
+{ "config": { "platform": { "php": "8.3" } } }
+JSON
+)
+run_case "platform.php 8.3"                "" "$OLD_PHP" "8.4" "8.3"
+
+# A patch-level platform pin is trimmed to major.minor for setup-php.
+PATCH_PHP=$(write_json <<'JSON'
+{ "config": { "platform": { "php": "8.5.0" } } }
+JSON
+)
+run_case "platform.php 8.5.0 trimmed"      "" "$PATCH_PHP" "8.4" "8.5"
+
+# No platform.php at all -> fall back to the bootstrap/default version.
+NO_PLATFORM=$(write_json <<'JSON'
+{ "config": {} }
+JSON
+)
+run_case "no platform.php, fallback 8.4"   "" "$NO_PLATFORM" "8.4" "8.4"
+run_case "no platform.php, fallback 8.2"   "" "$NO_PLATFORM" "8.2" "8.2"
+
+EMPTY=$(write_json <<'JSON'
+{}
+JSON
+)
+run_case "empty composer.json, fallback"   "" "$EMPTY" "8.3" "8.3"
+
+# An explicit override wins over config.platform.php (and is trimmed too).
+run_case "override wins over platform.php" "8.5" "$OLD_PHP" "8.4" "8.5"
+run_case "override patch trimmed"          "8.5.1" "$OLD_PHP" "8.4" "8.5"
+
+printf '\n%d passed, %d failed\n' "$pass" "$fail"
+[[ $fail -eq 0 ]]


### PR DESCRIPTION
The PHP-detection cases added in #1079 were only verified by hand — and the existing branch/version mirror tests weren't run by CI at all, so any of them could drift unnoticed. This adds a `ci-php-detection.sh` mirror test and runs all three mirror tests in the `bootstrap-tests` job so they're enforced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
