### PR TITLE
Create the .config dir in the salts step

### DIFF
--- a/.github/workflows/module-ci.yml
+++ b/.github/workflows/module-ci.yml
@@ -209,6 +209,7 @@ jobs:
         run: |
           set -euo pipefail
           cd "$HOME/test-root"
+          mkdir -p .config
           echo "<?php" > .config/salts.php
           curl -fsSL "https://api.wordpress.org/secret-key/1.1/salt/" >> .config/salts.php
           if [ ! -f .config/load.php ]; then


### PR DESCRIPTION
`.config/` in the test-root used to exist only as a side effect of dev-tools-command's Travis scaffolding; its 0.9.0 Travis→GHA refactor dropped that, so the salts step now fails writing `.config/salts.php` on master and every module's CI. Create the dir in the step instead of relying on the side effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
