### PR TITLE
Create the .config dir in the salts step (backport #1083 to v27-branch)

### DIFF
--- a/.github/workflows/module-ci.yml
+++ b/.github/workflows/module-ci.yml
@@ -180,6 +180,7 @@ jobs:
         run: |
           set -euo pipefail
           cd "$HOME/test-root"
+          mkdir -p .config
           echo "<?php" > .config/salts.php
           curl -fsSL "https://api.wordpress.org/secret-key/1.1/salt/" >> .config/salts.php
           if [ ! -f .config/load.php ]; then


### PR DESCRIPTION
Backport of #1083 to `v27-branch`. The auto-backporter couldn't do this one: the fix edits `.github/workflows/module-ci.yml`, and the backport action's `GITHUB_TOKEN` is refused when pushing workflow-file changes (`workflows` permission).